### PR TITLE
Create eac.plist for OS X / macOS

### DIFF
--- a/eac.plist
+++ b/eac.plist
@@ -1,0 +1,9434 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+<dict>
+	<key>phrase</key><string>&#x0023;&#x20e3;</string>
+	<key>shortcut</key><string>:hash:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x002a;&#x20e3;</string>
+	<key>shortcut</key><string>:asterisk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x002a;&#x20e3;</string>
+	<key>shortcut</key><string>:keycap_asterisk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x0030;&#x20e3;</string>
+	<key>shortcut</key><string>:zero:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x0031;&#x20e3;</string>
+	<key>shortcut</key><string>:one:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x0032;&#x20e3;</string>
+	<key>shortcut</key><string>:two:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x0033;&#x20e3;</string>
+	<key>shortcut</key><string>:three:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x0034;&#x20e3;</string>
+	<key>shortcut</key><string>:four:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x0035;&#x20e3;</string>
+	<key>shortcut</key><string>:five:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x0036;&#x20e3;</string>
+	<key>shortcut</key><string>:six:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x0037;&#x20e3;</string>
+	<key>shortcut</key><string>:seven:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x0038;&#x20e3;</string>
+	<key>shortcut</key><string>:eight:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x0039;&#x20e3;</string>
+	<key>shortcut</key><string>:nine:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x00a9;</string>
+	<key>shortcut</key><string>:copyright:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x00ae;</string>
+	<key>shortcut</key><string>:registered:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f004;</string>
+	<key>shortcut</key><string>:mahjong:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f0cf;</string>
+	<key>shortcut</key><string>:black_joker:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f170;</string>
+	<key>shortcut</key><string>:a:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f171;</string>
+	<key>shortcut</key><string>:b:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f17e;</string>
+	<key>shortcut</key><string>:o2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f17f;</string>
+	<key>shortcut</key><string>:parking:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f18e;</string>
+	<key>shortcut</key><string>:ab:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f191;</string>
+	<key>shortcut</key><string>:cl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f192;</string>
+	<key>shortcut</key><string>:cool:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f193;</string>
+	<key>shortcut</key><string>:free:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f194;</string>
+	<key>shortcut</key><string>:id:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f195;</string>
+	<key>shortcut</key><string>:new:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f196;</string>
+	<key>shortcut</key><string>:ng:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f197;</string>
+	<key>shortcut</key><string>:ok:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f198;</string>
+	<key>shortcut</key><string>:sos:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f199;</string>
+	<key>shortcut</key><string>:up:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f19a;</string>
+	<key>shortcut</key><string>:vs:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;</string>
+	<key>shortcut</key><string>:regional_indicator_a:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1e8;</string>
+	<key>shortcut</key><string>:flag_ac:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1e8;</string>
+	<key>shortcut</key><string>:ac:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1e9;</string>
+	<key>shortcut</key><string>:flag_ad:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1e9;</string>
+	<key>shortcut</key><string>:ad:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1ea;</string>
+	<key>shortcut</key><string>:flag_ae:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1ea;</string>
+	<key>shortcut</key><string>:ae:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1eb;</string>
+	<key>shortcut</key><string>:flag_af:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1eb;</string>
+	<key>shortcut</key><string>:af:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1ec;</string>
+	<key>shortcut</key><string>:flag_ag:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1ec;</string>
+	<key>shortcut</key><string>:ag:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1ee;</string>
+	<key>shortcut</key><string>:flag_ai:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1ee;</string>
+	<key>shortcut</key><string>:ai:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1f1;</string>
+	<key>shortcut</key><string>:flag_al:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1f1;</string>
+	<key>shortcut</key><string>:al:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1f2;</string>
+	<key>shortcut</key><string>:flag_am:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1f2;</string>
+	<key>shortcut</key><string>:am:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1f4;</string>
+	<key>shortcut</key><string>:flag_ao:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1f4;</string>
+	<key>shortcut</key><string>:ao:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1f6;</string>
+	<key>shortcut</key><string>:flag_aq:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1f6;</string>
+	<key>shortcut</key><string>:aq:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1f7;</string>
+	<key>shortcut</key><string>:flag_ar:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1f7;</string>
+	<key>shortcut</key><string>:ar:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1f8;</string>
+	<key>shortcut</key><string>:flag_as:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1f8;</string>
+	<key>shortcut</key><string>:as:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1f9;</string>
+	<key>shortcut</key><string>:flag_at:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1f9;</string>
+	<key>shortcut</key><string>:at:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1fa;</string>
+	<key>shortcut</key><string>:flag_au:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1fa;</string>
+	<key>shortcut</key><string>:au:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1fc;</string>
+	<key>shortcut</key><string>:flag_aw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1fc;</string>
+	<key>shortcut</key><string>:aw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1fd;</string>
+	<key>shortcut</key><string>:flag_ax:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1fd;</string>
+	<key>shortcut</key><string>:ax:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1ff;</string>
+	<key>shortcut</key><string>:flag_az:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e6;&#x1f1ff;</string>
+	<key>shortcut</key><string>:az:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;</string>
+	<key>shortcut</key><string>:regional_indicator_b:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1e6;</string>
+	<key>shortcut</key><string>:flag_ba:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1e6;</string>
+	<key>shortcut</key><string>:ba:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1e7;</string>
+	<key>shortcut</key><string>:flag_bb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1e7;</string>
+	<key>shortcut</key><string>:bb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1e9;</string>
+	<key>shortcut</key><string>:flag_bd:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1e9;</string>
+	<key>shortcut</key><string>:bd:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1ea;</string>
+	<key>shortcut</key><string>:flag_be:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1ea;</string>
+	<key>shortcut</key><string>:be:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1eb;</string>
+	<key>shortcut</key><string>:flag_bf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1eb;</string>
+	<key>shortcut</key><string>:bf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1ec;</string>
+	<key>shortcut</key><string>:flag_bg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1ec;</string>
+	<key>shortcut</key><string>:bg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1ed;</string>
+	<key>shortcut</key><string>:flag_bh:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1ed;</string>
+	<key>shortcut</key><string>:bh:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1ee;</string>
+	<key>shortcut</key><string>:flag_bi:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1ee;</string>
+	<key>shortcut</key><string>:bi:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1ef;</string>
+	<key>shortcut</key><string>:flag_bj:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1ef;</string>
+	<key>shortcut</key><string>:bj:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1f1;</string>
+	<key>shortcut</key><string>:flag_bl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1f1;</string>
+	<key>shortcut</key><string>:bl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1f2;</string>
+	<key>shortcut</key><string>:flag_bm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1f2;</string>
+	<key>shortcut</key><string>:bm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1f3;</string>
+	<key>shortcut</key><string>:flag_bn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1f3;</string>
+	<key>shortcut</key><string>:bn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1f4;</string>
+	<key>shortcut</key><string>:flag_bo:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1f4;</string>
+	<key>shortcut</key><string>:bo:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1f6;</string>
+	<key>shortcut</key><string>:flag_bq:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1f6;</string>
+	<key>shortcut</key><string>:bq:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1f7;</string>
+	<key>shortcut</key><string>:flag_br:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1f7;</string>
+	<key>shortcut</key><string>:br:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1f8;</string>
+	<key>shortcut</key><string>:flag_bs:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1f8;</string>
+	<key>shortcut</key><string>:bs:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1f9;</string>
+	<key>shortcut</key><string>:flag_bt:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1f9;</string>
+	<key>shortcut</key><string>:bt:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1fb;</string>
+	<key>shortcut</key><string>:flag_bv:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1fb;</string>
+	<key>shortcut</key><string>:bv:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1fc;</string>
+	<key>shortcut</key><string>:flag_bw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1fc;</string>
+	<key>shortcut</key><string>:bw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1fe;</string>
+	<key>shortcut</key><string>:flag_by:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1fe;</string>
+	<key>shortcut</key><string>:by:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1ff;</string>
+	<key>shortcut</key><string>:flag_bz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e7;&#x1f1ff;</string>
+	<key>shortcut</key><string>:bz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;</string>
+	<key>shortcut</key><string>:regional_indicator_c:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1e6;</string>
+	<key>shortcut</key><string>:flag_ca:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1e6;</string>
+	<key>shortcut</key><string>:ca:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1e8;</string>
+	<key>shortcut</key><string>:flag_cc:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1e8;</string>
+	<key>shortcut</key><string>:cc:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1e9;</string>
+	<key>shortcut</key><string>:flag_cd:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1e9;</string>
+	<key>shortcut</key><string>:congo:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1eb;</string>
+	<key>shortcut</key><string>:flag_cf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1eb;</string>
+	<key>shortcut</key><string>:cf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1ec;</string>
+	<key>shortcut</key><string>:flag_cg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1ec;</string>
+	<key>shortcut</key><string>:cg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1ed;</string>
+	<key>shortcut</key><string>:flag_ch:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1ed;</string>
+	<key>shortcut</key><string>:ch:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1ee;</string>
+	<key>shortcut</key><string>:flag_ci:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1ee;</string>
+	<key>shortcut</key><string>:ci:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1f0;</string>
+	<key>shortcut</key><string>:flag_ck:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1f0;</string>
+	<key>shortcut</key><string>:ck:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1f1;</string>
+	<key>shortcut</key><string>:flag_cl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1f1;</string>
+	<key>shortcut</key><string>:chile:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1f2;</string>
+	<key>shortcut</key><string>:flag_cm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1f2;</string>
+	<key>shortcut</key><string>:cm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1f3;</string>
+	<key>shortcut</key><string>:flag_cn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1f3;</string>
+	<key>shortcut</key><string>:cn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1f4;</string>
+	<key>shortcut</key><string>:flag_co:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1f4;</string>
+	<key>shortcut</key><string>:co:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1f5;</string>
+	<key>shortcut</key><string>:flag_cp:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1f5;</string>
+	<key>shortcut</key><string>:cp:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1f7;</string>
+	<key>shortcut</key><string>:flag_cr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1f7;</string>
+	<key>shortcut</key><string>:cr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1fa;</string>
+	<key>shortcut</key><string>:flag_cu:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1fa;</string>
+	<key>shortcut</key><string>:cu:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1fb;</string>
+	<key>shortcut</key><string>:flag_cv:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1fb;</string>
+	<key>shortcut</key><string>:cv:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1fc;</string>
+	<key>shortcut</key><string>:flag_cw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1fc;</string>
+	<key>shortcut</key><string>:cw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1fd;</string>
+	<key>shortcut</key><string>:flag_cx:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1fd;</string>
+	<key>shortcut</key><string>:cx:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1fe;</string>
+	<key>shortcut</key><string>:flag_cy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1fe;</string>
+	<key>shortcut</key><string>:cy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1ff;</string>
+	<key>shortcut</key><string>:flag_cz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e8;&#x1f1ff;</string>
+	<key>shortcut</key><string>:cz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e9;</string>
+	<key>shortcut</key><string>:regional_indicator_d:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e9;&#x1f1ea;</string>
+	<key>shortcut</key><string>:flag_de:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e9;&#x1f1ea;</string>
+	<key>shortcut</key><string>:de:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e9;&#x1f1ec;</string>
+	<key>shortcut</key><string>:flag_dg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e9;&#x1f1ec;</string>
+	<key>shortcut</key><string>:dg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e9;&#x1f1ef;</string>
+	<key>shortcut</key><string>:flag_dj:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e9;&#x1f1ef;</string>
+	<key>shortcut</key><string>:dj:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e9;&#x1f1f0;</string>
+	<key>shortcut</key><string>:flag_dk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e9;&#x1f1f0;</string>
+	<key>shortcut</key><string>:dk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e9;&#x1f1f2;</string>
+	<key>shortcut</key><string>:flag_dm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e9;&#x1f1f2;</string>
+	<key>shortcut</key><string>:dm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e9;&#x1f1f4;</string>
+	<key>shortcut</key><string>:flag_do:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e9;&#x1f1f4;</string>
+	<key>shortcut</key><string>:do:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e9;&#x1f1ff;</string>
+	<key>shortcut</key><string>:flag_dz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1e9;&#x1f1ff;</string>
+	<key>shortcut</key><string>:dz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;</string>
+	<key>shortcut</key><string>:regional_indicator_e:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1e6;</string>
+	<key>shortcut</key><string>:flag_ea:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1e6;</string>
+	<key>shortcut</key><string>:ea:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1e8;</string>
+	<key>shortcut</key><string>:flag_ec:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1e8;</string>
+	<key>shortcut</key><string>:ec:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1ea;</string>
+	<key>shortcut</key><string>:flag_ee:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1ea;</string>
+	<key>shortcut</key><string>:ee:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1ec;</string>
+	<key>shortcut</key><string>:flag_eg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1ec;</string>
+	<key>shortcut</key><string>:eg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1ed;</string>
+	<key>shortcut</key><string>:flag_eh:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1ed;</string>
+	<key>shortcut</key><string>:eh:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1f7;</string>
+	<key>shortcut</key><string>:flag_er:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1f7;</string>
+	<key>shortcut</key><string>:er:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1f8;</string>
+	<key>shortcut</key><string>:flag_es:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1f8;</string>
+	<key>shortcut</key><string>:es:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1f9;</string>
+	<key>shortcut</key><string>:flag_et:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1f9;</string>
+	<key>shortcut</key><string>:et:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1fa;</string>
+	<key>shortcut</key><string>:flag_eu:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ea;&#x1f1fa;</string>
+	<key>shortcut</key><string>:eu:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1eb;</string>
+	<key>shortcut</key><string>:regional_indicator_f:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1eb;&#x1f1ee;</string>
+	<key>shortcut</key><string>:flag_fi:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1eb;&#x1f1ee;</string>
+	<key>shortcut</key><string>:fi:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1eb;&#x1f1ef;</string>
+	<key>shortcut</key><string>:flag_fj:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1eb;&#x1f1ef;</string>
+	<key>shortcut</key><string>:fj:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1eb;&#x1f1f0;</string>
+	<key>shortcut</key><string>:flag_fk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1eb;&#x1f1f0;</string>
+	<key>shortcut</key><string>:fk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1eb;&#x1f1f2;</string>
+	<key>shortcut</key><string>:flag_fm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1eb;&#x1f1f2;</string>
+	<key>shortcut</key><string>:fm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1eb;&#x1f1f4;</string>
+	<key>shortcut</key><string>:flag_fo:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1eb;&#x1f1f4;</string>
+	<key>shortcut</key><string>:fo:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1eb;&#x1f1f7;</string>
+	<key>shortcut</key><string>:flag_fr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1eb;&#x1f1f7;</string>
+	<key>shortcut</key><string>:fr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;</string>
+	<key>shortcut</key><string>:regional_indicator_g:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1e6;</string>
+	<key>shortcut</key><string>:flag_ga:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1e6;</string>
+	<key>shortcut</key><string>:ga:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1e7;</string>
+	<key>shortcut</key><string>:flag_gb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1e7;</string>
+	<key>shortcut</key><string>:gb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1e9;</string>
+	<key>shortcut</key><string>:flag_gd:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1e9;</string>
+	<key>shortcut</key><string>:gd:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1ea;</string>
+	<key>shortcut</key><string>:flag_ge:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1ea;</string>
+	<key>shortcut</key><string>:ge:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1eb;</string>
+	<key>shortcut</key><string>:flag_gf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1eb;</string>
+	<key>shortcut</key><string>:gf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1ec;</string>
+	<key>shortcut</key><string>:flag_gg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1ec;</string>
+	<key>shortcut</key><string>:gg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1ed;</string>
+	<key>shortcut</key><string>:flag_gh:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1ed;</string>
+	<key>shortcut</key><string>:gh:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1ee;</string>
+	<key>shortcut</key><string>:flag_gi:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1ee;</string>
+	<key>shortcut</key><string>:gi:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1f1;</string>
+	<key>shortcut</key><string>:flag_gl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1f1;</string>
+	<key>shortcut</key><string>:gl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1f2;</string>
+	<key>shortcut</key><string>:flag_gm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1f2;</string>
+	<key>shortcut</key><string>:gm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1f3;</string>
+	<key>shortcut</key><string>:flag_gn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1f3;</string>
+	<key>shortcut</key><string>:gn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1f5;</string>
+	<key>shortcut</key><string>:flag_gp:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1f5;</string>
+	<key>shortcut</key><string>:gp:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1f6;</string>
+	<key>shortcut</key><string>:flag_gq:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1f6;</string>
+	<key>shortcut</key><string>:gq:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1f7;</string>
+	<key>shortcut</key><string>:flag_gr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1f7;</string>
+	<key>shortcut</key><string>:gr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1f8;</string>
+	<key>shortcut</key><string>:flag_gs:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1f8;</string>
+	<key>shortcut</key><string>:gs:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1f9;</string>
+	<key>shortcut</key><string>:flag_gt:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1f9;</string>
+	<key>shortcut</key><string>:gt:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1fa;</string>
+	<key>shortcut</key><string>:flag_gu:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1fa;</string>
+	<key>shortcut</key><string>:gu:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1fc;</string>
+	<key>shortcut</key><string>:flag_gw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1fc;</string>
+	<key>shortcut</key><string>:gw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1fe;</string>
+	<key>shortcut</key><string>:flag_gy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ec;&#x1f1fe;</string>
+	<key>shortcut</key><string>:gy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ed;</string>
+	<key>shortcut</key><string>:regional_indicator_h:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ed;&#x1f1f0;</string>
+	<key>shortcut</key><string>:flag_hk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ed;&#x1f1f0;</string>
+	<key>shortcut</key><string>:hk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ed;&#x1f1f2;</string>
+	<key>shortcut</key><string>:flag_hm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ed;&#x1f1f2;</string>
+	<key>shortcut</key><string>:hm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ed;&#x1f1f3;</string>
+	<key>shortcut</key><string>:flag_hn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ed;&#x1f1f3;</string>
+	<key>shortcut</key><string>:hn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ed;&#x1f1f7;</string>
+	<key>shortcut</key><string>:flag_hr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ed;&#x1f1f7;</string>
+	<key>shortcut</key><string>:hr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ed;&#x1f1f9;</string>
+	<key>shortcut</key><string>:flag_ht:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ed;&#x1f1f9;</string>
+	<key>shortcut</key><string>:ht:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ed;&#x1f1fa;</string>
+	<key>shortcut</key><string>:flag_hu:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ed;&#x1f1fa;</string>
+	<key>shortcut</key><string>:hu:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;</string>
+	<key>shortcut</key><string>:regional_indicator_i:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1e8;</string>
+	<key>shortcut</key><string>:flag_ic:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1e8;</string>
+	<key>shortcut</key><string>:ic:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1e9;</string>
+	<key>shortcut</key><string>:flag_id:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1e9;</string>
+	<key>shortcut</key><string>:indonesia:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1ea;</string>
+	<key>shortcut</key><string>:flag_ie:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1ea;</string>
+	<key>shortcut</key><string>:ie:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1f1;</string>
+	<key>shortcut</key><string>:flag_il:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1f1;</string>
+	<key>shortcut</key><string>:il:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1f2;</string>
+	<key>shortcut</key><string>:flag_im:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1f2;</string>
+	<key>shortcut</key><string>:im:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1f3;</string>
+	<key>shortcut</key><string>:flag_in:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1f3;</string>
+	<key>shortcut</key><string>:in:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1f4;</string>
+	<key>shortcut</key><string>:flag_io:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1f4;</string>
+	<key>shortcut</key><string>:io:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1f6;</string>
+	<key>shortcut</key><string>:flag_iq:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1f6;</string>
+	<key>shortcut</key><string>:iq:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1f7;</string>
+	<key>shortcut</key><string>:flag_ir:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1f7;</string>
+	<key>shortcut</key><string>:ir:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1f8;</string>
+	<key>shortcut</key><string>:flag_is:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1f8;</string>
+	<key>shortcut</key><string>:is:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1f9;</string>
+	<key>shortcut</key><string>:flag_it:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ee;&#x1f1f9;</string>
+	<key>shortcut</key><string>:it:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ef;</string>
+	<key>shortcut</key><string>:regional_indicator_j:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ef;&#x1f1ea;</string>
+	<key>shortcut</key><string>:flag_je:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ef;&#x1f1ea;</string>
+	<key>shortcut</key><string>:je:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ef;&#x1f1f2;</string>
+	<key>shortcut</key><string>:flag_jm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ef;&#x1f1f2;</string>
+	<key>shortcut</key><string>:jm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ef;&#x1f1f4;</string>
+	<key>shortcut</key><string>:flag_jo:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ef;&#x1f1f4;</string>
+	<key>shortcut</key><string>:jo:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ef;&#x1f1f5;</string>
+	<key>shortcut</key><string>:flag_jp:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ef;&#x1f1f5;</string>
+	<key>shortcut</key><string>:jp:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;</string>
+	<key>shortcut</key><string>:regional_indicator_k:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1ea;</string>
+	<key>shortcut</key><string>:flag_ke:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1ea;</string>
+	<key>shortcut</key><string>:ke:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1ec;</string>
+	<key>shortcut</key><string>:flag_kg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1ec;</string>
+	<key>shortcut</key><string>:kg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1ed;</string>
+	<key>shortcut</key><string>:flag_kh:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1ed;</string>
+	<key>shortcut</key><string>:kh:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1ee;</string>
+	<key>shortcut</key><string>:flag_ki:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1ee;</string>
+	<key>shortcut</key><string>:ki:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1f2;</string>
+	<key>shortcut</key><string>:flag_km:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1f2;</string>
+	<key>shortcut</key><string>:km:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1f3;</string>
+	<key>shortcut</key><string>:flag_kn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1f3;</string>
+	<key>shortcut</key><string>:kn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1f5;</string>
+	<key>shortcut</key><string>:flag_kp:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1f5;</string>
+	<key>shortcut</key><string>:kp:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1f7;</string>
+	<key>shortcut</key><string>:flag_kr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1f7;</string>
+	<key>shortcut</key><string>:kr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1fc;</string>
+	<key>shortcut</key><string>:flag_kw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1fc;</string>
+	<key>shortcut</key><string>:kw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1fe;</string>
+	<key>shortcut</key><string>:flag_ky:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1fe;</string>
+	<key>shortcut</key><string>:ky:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1ff;</string>
+	<key>shortcut</key><string>:flag_kz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f0;&#x1f1ff;</string>
+	<key>shortcut</key><string>:kz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;</string>
+	<key>shortcut</key><string>:regional_indicator_l:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1e6;</string>
+	<key>shortcut</key><string>:flag_la:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1e6;</string>
+	<key>shortcut</key><string>:la:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1e7;</string>
+	<key>shortcut</key><string>:flag_lb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1e7;</string>
+	<key>shortcut</key><string>:lb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1e8;</string>
+	<key>shortcut</key><string>:flag_lc:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1e8;</string>
+	<key>shortcut</key><string>:lc:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1ee;</string>
+	<key>shortcut</key><string>:flag_li:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1ee;</string>
+	<key>shortcut</key><string>:li:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1f0;</string>
+	<key>shortcut</key><string>:flag_lk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1f0;</string>
+	<key>shortcut</key><string>:lk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1f7;</string>
+	<key>shortcut</key><string>:flag_lr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1f7;</string>
+	<key>shortcut</key><string>:lr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1f8;</string>
+	<key>shortcut</key><string>:flag_ls:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1f8;</string>
+	<key>shortcut</key><string>:ls:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1f9;</string>
+	<key>shortcut</key><string>:flag_lt:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1f9;</string>
+	<key>shortcut</key><string>:lt:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1fa;</string>
+	<key>shortcut</key><string>:flag_lu:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1fa;</string>
+	<key>shortcut</key><string>:lu:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1fb;</string>
+	<key>shortcut</key><string>:flag_lv:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1fb;</string>
+	<key>shortcut</key><string>:lv:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1fe;</string>
+	<key>shortcut</key><string>:flag_ly:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f1;&#x1f1fe;</string>
+	<key>shortcut</key><string>:ly:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;</string>
+	<key>shortcut</key><string>:regional_indicator_m:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1e6;</string>
+	<key>shortcut</key><string>:flag_ma:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1e6;</string>
+	<key>shortcut</key><string>:ma:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1e8;</string>
+	<key>shortcut</key><string>:flag_mc:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1e8;</string>
+	<key>shortcut</key><string>:mc:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1e9;</string>
+	<key>shortcut</key><string>:flag_md:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1e9;</string>
+	<key>shortcut</key><string>:md:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1ea;</string>
+	<key>shortcut</key><string>:flag_me:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1ea;</string>
+	<key>shortcut</key><string>:me:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1eb;</string>
+	<key>shortcut</key><string>:flag_mf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1eb;</string>
+	<key>shortcut</key><string>:mf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1ec;</string>
+	<key>shortcut</key><string>:flag_mg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1ec;</string>
+	<key>shortcut</key><string>:mg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1ed;</string>
+	<key>shortcut</key><string>:flag_mh:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1ed;</string>
+	<key>shortcut</key><string>:mh:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f0;</string>
+	<key>shortcut</key><string>:flag_mk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f0;</string>
+	<key>shortcut</key><string>:mk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f1;</string>
+	<key>shortcut</key><string>:flag_ml:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f1;</string>
+	<key>shortcut</key><string>:ml:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f2;</string>
+	<key>shortcut</key><string>:flag_mm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f2;</string>
+	<key>shortcut</key><string>:mm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f3;</string>
+	<key>shortcut</key><string>:flag_mn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f3;</string>
+	<key>shortcut</key><string>:mn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f4;</string>
+	<key>shortcut</key><string>:flag_mo:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f4;</string>
+	<key>shortcut</key><string>:mo:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f5;</string>
+	<key>shortcut</key><string>:flag_mp:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f5;</string>
+	<key>shortcut</key><string>:mp:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f6;</string>
+	<key>shortcut</key><string>:flag_mq:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f6;</string>
+	<key>shortcut</key><string>:mq:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f7;</string>
+	<key>shortcut</key><string>:flag_mr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f7;</string>
+	<key>shortcut</key><string>:mr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f8;</string>
+	<key>shortcut</key><string>:flag_ms:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f8;</string>
+	<key>shortcut</key><string>:ms:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f9;</string>
+	<key>shortcut</key><string>:flag_mt:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1f9;</string>
+	<key>shortcut</key><string>:mt:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1fa;</string>
+	<key>shortcut</key><string>:flag_mu:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1fa;</string>
+	<key>shortcut</key><string>:mu:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1fb;</string>
+	<key>shortcut</key><string>:flag_mv:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1fb;</string>
+	<key>shortcut</key><string>:mv:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1fc;</string>
+	<key>shortcut</key><string>:flag_mw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1fc;</string>
+	<key>shortcut</key><string>:mw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1fd;</string>
+	<key>shortcut</key><string>:flag_mx:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1fd;</string>
+	<key>shortcut</key><string>:mx:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1fe;</string>
+	<key>shortcut</key><string>:flag_my:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1fe;</string>
+	<key>shortcut</key><string>:my:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1ff;</string>
+	<key>shortcut</key><string>:flag_mz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f2;&#x1f1ff;</string>
+	<key>shortcut</key><string>:mz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;</string>
+	<key>shortcut</key><string>:regional_indicator_n:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1e6;</string>
+	<key>shortcut</key><string>:flag_na:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1e6;</string>
+	<key>shortcut</key><string>:na:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1e8;</string>
+	<key>shortcut</key><string>:flag_nc:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1e8;</string>
+	<key>shortcut</key><string>:nc:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1ea;</string>
+	<key>shortcut</key><string>:flag_ne:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1ea;</string>
+	<key>shortcut</key><string>:ne:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1eb;</string>
+	<key>shortcut</key><string>:flag_nf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1eb;</string>
+	<key>shortcut</key><string>:nf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1ec;</string>
+	<key>shortcut</key><string>:flag_ng:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1ec;</string>
+	<key>shortcut</key><string>:nigeria:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1ee;</string>
+	<key>shortcut</key><string>:flag_ni:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1ee;</string>
+	<key>shortcut</key><string>:ni:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1f1;</string>
+	<key>shortcut</key><string>:flag_nl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1f1;</string>
+	<key>shortcut</key><string>:nl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1f4;</string>
+	<key>shortcut</key><string>:flag_no:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1f4;</string>
+	<key>shortcut</key><string>:no:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1f5;</string>
+	<key>shortcut</key><string>:flag_np:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1f5;</string>
+	<key>shortcut</key><string>:np:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1f7;</string>
+	<key>shortcut</key><string>:flag_nr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1f7;</string>
+	<key>shortcut</key><string>:nr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1fa;</string>
+	<key>shortcut</key><string>:flag_nu:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1fa;</string>
+	<key>shortcut</key><string>:nu:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1ff;</string>
+	<key>shortcut</key><string>:flag_nz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f3;&#x1f1ff;</string>
+	<key>shortcut</key><string>:nz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f4;</string>
+	<key>shortcut</key><string>:regional_indicator_o:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f4;&#x1f1f2;</string>
+	<key>shortcut</key><string>:flag_om:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f4;&#x1f1f2;</string>
+	<key>shortcut</key><string>:om:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;</string>
+	<key>shortcut</key><string>:regional_indicator_p:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1e6;</string>
+	<key>shortcut</key><string>:flag_pa:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1e6;</string>
+	<key>shortcut</key><string>:pa:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1ea;</string>
+	<key>shortcut</key><string>:flag_pe:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1ea;</string>
+	<key>shortcut</key><string>:pe:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1eb;</string>
+	<key>shortcut</key><string>:flag_pf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1eb;</string>
+	<key>shortcut</key><string>:pf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1ec;</string>
+	<key>shortcut</key><string>:flag_pg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1ec;</string>
+	<key>shortcut</key><string>:pg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1ed;</string>
+	<key>shortcut</key><string>:flag_ph:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1ed;</string>
+	<key>shortcut</key><string>:ph:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1f0;</string>
+	<key>shortcut</key><string>:flag_pk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1f0;</string>
+	<key>shortcut</key><string>:pk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1f1;</string>
+	<key>shortcut</key><string>:flag_pl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1f1;</string>
+	<key>shortcut</key><string>:pl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1f2;</string>
+	<key>shortcut</key><string>:flag_pm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1f2;</string>
+	<key>shortcut</key><string>:pm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1f3;</string>
+	<key>shortcut</key><string>:flag_pn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1f3;</string>
+	<key>shortcut</key><string>:pn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1f7;</string>
+	<key>shortcut</key><string>:flag_pr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1f7;</string>
+	<key>shortcut</key><string>:pr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1f8;</string>
+	<key>shortcut</key><string>:flag_ps:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1f8;</string>
+	<key>shortcut</key><string>:ps:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1f9;</string>
+	<key>shortcut</key><string>:flag_pt:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1f9;</string>
+	<key>shortcut</key><string>:pt:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1fc;</string>
+	<key>shortcut</key><string>:flag_pw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1fc;</string>
+	<key>shortcut</key><string>:pw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1fe;</string>
+	<key>shortcut</key><string>:flag_py:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f5;&#x1f1fe;</string>
+	<key>shortcut</key><string>:py:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f6;</string>
+	<key>shortcut</key><string>:regional_indicator_q:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f6;&#x1f1e6;</string>
+	<key>shortcut</key><string>:flag_qa:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f6;&#x1f1e6;</string>
+	<key>shortcut</key><string>:qa:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f7;</string>
+	<key>shortcut</key><string>:regional_indicator_r:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f7;&#x1f1ea;</string>
+	<key>shortcut</key><string>:flag_re:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f7;&#x1f1ea;</string>
+	<key>shortcut</key><string>:re:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f7;&#x1f1f4;</string>
+	<key>shortcut</key><string>:flag_ro:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f7;&#x1f1f4;</string>
+	<key>shortcut</key><string>:ro:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f7;&#x1f1f8;</string>
+	<key>shortcut</key><string>:flag_rs:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f7;&#x1f1f8;</string>
+	<key>shortcut</key><string>:rs:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f7;&#x1f1fa;</string>
+	<key>shortcut</key><string>:flag_ru:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f7;&#x1f1fa;</string>
+	<key>shortcut</key><string>:ru:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f7;&#x1f1fc;</string>
+	<key>shortcut</key><string>:flag_rw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f7;&#x1f1fc;</string>
+	<key>shortcut</key><string>:rw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;</string>
+	<key>shortcut</key><string>:regional_indicator_s:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1e6;</string>
+	<key>shortcut</key><string>:flag_sa:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1e6;</string>
+	<key>shortcut</key><string>:saudiarabia:|:saudi:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1e7;</string>
+	<key>shortcut</key><string>:flag_sb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1e7;</string>
+	<key>shortcut</key><string>:sb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1e8;</string>
+	<key>shortcut</key><string>:flag_sc:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1e8;</string>
+	<key>shortcut</key><string>:sc:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1e9;</string>
+	<key>shortcut</key><string>:flag_sd:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1e9;</string>
+	<key>shortcut</key><string>:sd:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1ea;</string>
+	<key>shortcut</key><string>:flag_se:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1ea;</string>
+	<key>shortcut</key><string>:se:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1ec;</string>
+	<key>shortcut</key><string>:flag_sg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1ec;</string>
+	<key>shortcut</key><string>:sg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1ed;</string>
+	<key>shortcut</key><string>:flag_sh:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1ed;</string>
+	<key>shortcut</key><string>:sh:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1ee;</string>
+	<key>shortcut</key><string>:flag_si:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1ee;</string>
+	<key>shortcut</key><string>:si:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1ef;</string>
+	<key>shortcut</key><string>:flag_sj:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1ef;</string>
+	<key>shortcut</key><string>:sj:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1f0;</string>
+	<key>shortcut</key><string>:flag_sk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1f0;</string>
+	<key>shortcut</key><string>:sk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1f1;</string>
+	<key>shortcut</key><string>:flag_sl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1f1;</string>
+	<key>shortcut</key><string>:sl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1f2;</string>
+	<key>shortcut</key><string>:flag_sm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1f2;</string>
+	<key>shortcut</key><string>:sm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1f3;</string>
+	<key>shortcut</key><string>:flag_sn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1f3;</string>
+	<key>shortcut</key><string>:sn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1f4;</string>
+	<key>shortcut</key><string>:flag_so:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1f4;</string>
+	<key>shortcut</key><string>:so:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1f7;</string>
+	<key>shortcut</key><string>:flag_sr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1f7;</string>
+	<key>shortcut</key><string>:sr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1f8;</string>
+	<key>shortcut</key><string>:flag_ss:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1f8;</string>
+	<key>shortcut</key><string>:ss:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1f9;</string>
+	<key>shortcut</key><string>:flag_st:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1f9;</string>
+	<key>shortcut</key><string>:st:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1fb;</string>
+	<key>shortcut</key><string>:flag_sv:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1fb;</string>
+	<key>shortcut</key><string>:sv:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1fd;</string>
+	<key>shortcut</key><string>:flag_sx:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1fd;</string>
+	<key>shortcut</key><string>:sx:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1fe;</string>
+	<key>shortcut</key><string>:flag_sy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1fe;</string>
+	<key>shortcut</key><string>:sy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1ff;</string>
+	<key>shortcut</key><string>:flag_sz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f8;&#x1f1ff;</string>
+	<key>shortcut</key><string>:sz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;</string>
+	<key>shortcut</key><string>:regional_indicator_t:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1e6;</string>
+	<key>shortcut</key><string>:flag_ta:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1e6;</string>
+	<key>shortcut</key><string>:ta:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1e8;</string>
+	<key>shortcut</key><string>:flag_tc:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1e8;</string>
+	<key>shortcut</key><string>:tc:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1e9;</string>
+	<key>shortcut</key><string>:flag_td:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1e9;</string>
+	<key>shortcut</key><string>:td:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1eb;</string>
+	<key>shortcut</key><string>:flag_tf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1eb;</string>
+	<key>shortcut</key><string>:tf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1ec;</string>
+	<key>shortcut</key><string>:flag_tg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1ec;</string>
+	<key>shortcut</key><string>:tg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1ed;</string>
+	<key>shortcut</key><string>:flag_th:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1ed;</string>
+	<key>shortcut</key><string>:th:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1ef;</string>
+	<key>shortcut</key><string>:flag_tj:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1ef;</string>
+	<key>shortcut</key><string>:tj:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1f0;</string>
+	<key>shortcut</key><string>:flag_tk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1f0;</string>
+	<key>shortcut</key><string>:tk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1f1;</string>
+	<key>shortcut</key><string>:flag_tl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1f1;</string>
+	<key>shortcut</key><string>:tl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1f2;</string>
+	<key>shortcut</key><string>:flag_tm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1f2;</string>
+	<key>shortcut</key><string>:turkmenistan:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1f3;</string>
+	<key>shortcut</key><string>:flag_tn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1f3;</string>
+	<key>shortcut</key><string>:tn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1f4;</string>
+	<key>shortcut</key><string>:flag_to:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1f4;</string>
+	<key>shortcut</key><string>:to:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1f7;</string>
+	<key>shortcut</key><string>:flag_tr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1f7;</string>
+	<key>shortcut</key><string>:tr:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1f9;</string>
+	<key>shortcut</key><string>:flag_tt:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1f9;</string>
+	<key>shortcut</key><string>:tt:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1fb;</string>
+	<key>shortcut</key><string>:flag_tv:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1fb;</string>
+	<key>shortcut</key><string>:tuvalu:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1fc;</string>
+	<key>shortcut</key><string>:flag_tw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1fc;</string>
+	<key>shortcut</key><string>:tw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1ff;</string>
+	<key>shortcut</key><string>:flag_tz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1f9;&#x1f1ff;</string>
+	<key>shortcut</key><string>:tz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fa;</string>
+	<key>shortcut</key><string>:regional_indicator_u:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fa;&#x1f1e6;</string>
+	<key>shortcut</key><string>:flag_ua:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fa;&#x1f1e6;</string>
+	<key>shortcut</key><string>:ua:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fa;&#x1f1ec;</string>
+	<key>shortcut</key><string>:flag_ug:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fa;&#x1f1ec;</string>
+	<key>shortcut</key><string>:ug:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fa;&#x1f1f2;</string>
+	<key>shortcut</key><string>:flag_um:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fa;&#x1f1f2;</string>
+	<key>shortcut</key><string>:um:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fa;&#x1f1f8;</string>
+	<key>shortcut</key><string>:flag_us:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fa;&#x1f1f8;</string>
+	<key>shortcut</key><string>:us:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fa;&#x1f1fe;</string>
+	<key>shortcut</key><string>:flag_uy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fa;&#x1f1fe;</string>
+	<key>shortcut</key><string>:uy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fa;&#x1f1ff;</string>
+	<key>shortcut</key><string>:flag_uz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fa;&#x1f1ff;</string>
+	<key>shortcut</key><string>:uz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fb;</string>
+	<key>shortcut</key><string>:regional_indicator_v:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fb;&#x1f1e6;</string>
+	<key>shortcut</key><string>:flag_va:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fb;&#x1f1e6;</string>
+	<key>shortcut</key><string>:va:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fb;&#x1f1e8;</string>
+	<key>shortcut</key><string>:flag_vc:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fb;&#x1f1e8;</string>
+	<key>shortcut</key><string>:vc:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fb;&#x1f1ea;</string>
+	<key>shortcut</key><string>:flag_ve:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fb;&#x1f1ea;</string>
+	<key>shortcut</key><string>:ve:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fb;&#x1f1ec;</string>
+	<key>shortcut</key><string>:flag_vg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fb;&#x1f1ec;</string>
+	<key>shortcut</key><string>:vg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fb;&#x1f1ee;</string>
+	<key>shortcut</key><string>:flag_vi:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fb;&#x1f1ee;</string>
+	<key>shortcut</key><string>:vi:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fb;&#x1f1f3;</string>
+	<key>shortcut</key><string>:flag_vn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fb;&#x1f1f3;</string>
+	<key>shortcut</key><string>:vn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fb;&#x1f1fa;</string>
+	<key>shortcut</key><string>:flag_vu:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fb;&#x1f1fa;</string>
+	<key>shortcut</key><string>:vu:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fc;</string>
+	<key>shortcut</key><string>:regional_indicator_w:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fc;&#x1f1eb;</string>
+	<key>shortcut</key><string>:flag_wf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fc;&#x1f1eb;</string>
+	<key>shortcut</key><string>:wf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fc;&#x1f1f8;</string>
+	<key>shortcut</key><string>:flag_ws:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fc;&#x1f1f8;</string>
+	<key>shortcut</key><string>:ws:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fd;</string>
+	<key>shortcut</key><string>:regional_indicator_x:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fd;&#x1f1f0;</string>
+	<key>shortcut</key><string>:flag_xk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fd;&#x1f1f0;</string>
+	<key>shortcut</key><string>:xk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fe;</string>
+	<key>shortcut</key><string>:regional_indicator_y:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fe;&#x1f1ea;</string>
+	<key>shortcut</key><string>:flag_ye:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fe;&#x1f1ea;</string>
+	<key>shortcut</key><string>:ye:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fe;&#x1f1f9;</string>
+	<key>shortcut</key><string>:flag_yt:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1fe;&#x1f1f9;</string>
+	<key>shortcut</key><string>:yt:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ff;</string>
+	<key>shortcut</key><string>:regional_indicator_z:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ff;&#x1f1e6;</string>
+	<key>shortcut</key><string>:flag_za:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ff;&#x1f1e6;</string>
+	<key>shortcut</key><string>:za:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ff;&#x1f1f2;</string>
+	<key>shortcut</key><string>:flag_zm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ff;&#x1f1f2;</string>
+	<key>shortcut</key><string>:zm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ff;&#x1f1fc;</string>
+	<key>shortcut</key><string>:flag_zw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f1ff;&#x1f1fc;</string>
+	<key>shortcut</key><string>:zw:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f201;</string>
+	<key>shortcut</key><string>:koko:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f202;</string>
+	<key>shortcut</key><string>:sa:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f21a;</string>
+	<key>shortcut</key><string>:u7121:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f22f;</string>
+	<key>shortcut</key><string>:u6307:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f232;</string>
+	<key>shortcut</key><string>:u7981:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f233;</string>
+	<key>shortcut</key><string>:u7a7a:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f234;</string>
+	<key>shortcut</key><string>:u5408:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f235;</string>
+	<key>shortcut</key><string>:u6e80:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f236;</string>
+	<key>shortcut</key><string>:u6709:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f237;</string>
+	<key>shortcut</key><string>:u6708:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f238;</string>
+	<key>shortcut</key><string>:u7533:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f239;</string>
+	<key>shortcut</key><string>:u5272:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f23a;</string>
+	<key>shortcut</key><string>:u55b6:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f250;</string>
+	<key>shortcut</key><string>:ideograph_advantage:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f251;</string>
+	<key>shortcut</key><string>:accept:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f300;</string>
+	<key>shortcut</key><string>:cyclone:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f301;</string>
+	<key>shortcut</key><string>:foggy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f302;</string>
+	<key>shortcut</key><string>:closed_umbrella:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f303;</string>
+	<key>shortcut</key><string>:night_with_stars:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f304;</string>
+	<key>shortcut</key><string>:sunrise_over_mountains:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f305;</string>
+	<key>shortcut</key><string>:sunrise:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f306;</string>
+	<key>shortcut</key><string>:city_dusk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f307;</string>
+	<key>shortcut</key><string>:city_sunset:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f307;</string>
+	<key>shortcut</key><string>:city_sunrise:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f308;</string>
+	<key>shortcut</key><string>:rainbow:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f309;</string>
+	<key>shortcut</key><string>:bridge_at_night:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f30a;</string>
+	<key>shortcut</key><string>:ocean:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f30b;</string>
+	<key>shortcut</key><string>:volcano:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f30c;</string>
+	<key>shortcut</key><string>:milky_way:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f30d;</string>
+	<key>shortcut</key><string>:earth_africa:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f30e;</string>
+	<key>shortcut</key><string>:earth_americas:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f30f;</string>
+	<key>shortcut</key><string>:earth_asia:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f310;</string>
+	<key>shortcut</key><string>:globe_with_meridians:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f311;</string>
+	<key>shortcut</key><string>:new_moon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f312;</string>
+	<key>shortcut</key><string>:waxing_crescent_moon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f313;</string>
+	<key>shortcut</key><string>:first_quarter_moon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f314;</string>
+	<key>shortcut</key><string>:waxing_gibbous_moon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f315;</string>
+	<key>shortcut</key><string>:full_moon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f316;</string>
+	<key>shortcut</key><string>:waning_gibbous_moon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f317;</string>
+	<key>shortcut</key><string>:last_quarter_moon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f318;</string>
+	<key>shortcut</key><string>:waning_crescent_moon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f319;</string>
+	<key>shortcut</key><string>:crescent_moon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f31a;</string>
+	<key>shortcut</key><string>:new_moon_with_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f31b;</string>
+	<key>shortcut</key><string>:first_quarter_moon_with_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f31c;</string>
+	<key>shortcut</key><string>:last_quarter_moon_with_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f31d;</string>
+	<key>shortcut</key><string>:full_moon_with_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f31e;</string>
+	<key>shortcut</key><string>:sun_with_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f31f;</string>
+	<key>shortcut</key><string>:star2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f320;</string>
+	<key>shortcut</key><string>:stars:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f321;</string>
+	<key>shortcut</key><string>:thermometer:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f324;</string>
+	<key>shortcut</key><string>:white_sun_small_cloud:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f324;</string>
+	<key>shortcut</key><string>:white_sun_with_small_cloud:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f325;</string>
+	<key>shortcut</key><string>:white_sun_cloud:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f325;</string>
+	<key>shortcut</key><string>:white_sun_behind_cloud:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f326;</string>
+	<key>shortcut</key><string>:white_sun_rain_cloud:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f326;</string>
+	<key>shortcut</key><string>:white_sun_behind_cloud_with_rain:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f327;</string>
+	<key>shortcut</key><string>:cloud_rain:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f327;</string>
+	<key>shortcut</key><string>:cloud_with_rain:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f328;</string>
+	<key>shortcut</key><string>:cloud_snow:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f328;</string>
+	<key>shortcut</key><string>:cloud_with_snow:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f329;</string>
+	<key>shortcut</key><string>:cloud_lightning:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f329;</string>
+	<key>shortcut</key><string>:cloud_with_lightning:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f32a;</string>
+	<key>shortcut</key><string>:cloud_tornado:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f32a;</string>
+	<key>shortcut</key><string>:cloud_with_tornado:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f32b;</string>
+	<key>shortcut</key><string>:fog:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f32c;</string>
+	<key>shortcut</key><string>:wind_blowing_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f32d;</string>
+	<key>shortcut</key><string>:hotdog:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f32d;</string>
+	<key>shortcut</key><string>:hot_dog:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f32e;</string>
+	<key>shortcut</key><string>:taco:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f32f;</string>
+	<key>shortcut</key><string>:burrito:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f330;</string>
+	<key>shortcut</key><string>:chestnut:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f331;</string>
+	<key>shortcut</key><string>:seedling:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f332;</string>
+	<key>shortcut</key><string>:evergreen_tree:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f333;</string>
+	<key>shortcut</key><string>:deciduous_tree:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f334;</string>
+	<key>shortcut</key><string>:palm_tree:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f335;</string>
+	<key>shortcut</key><string>:cactus:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f336;</string>
+	<key>shortcut</key><string>:hot_pepper:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f337;</string>
+	<key>shortcut</key><string>:tulip:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f338;</string>
+	<key>shortcut</key><string>:cherry_blossom:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f339;</string>
+	<key>shortcut</key><string>:rose:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f33a;</string>
+	<key>shortcut</key><string>:hibiscus:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f33b;</string>
+	<key>shortcut</key><string>:sunflower:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f33c;</string>
+	<key>shortcut</key><string>:blossom:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f33d;</string>
+	<key>shortcut</key><string>:corn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f33e;</string>
+	<key>shortcut</key><string>:ear_of_rice:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f33f;</string>
+	<key>shortcut</key><string>:herb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f340;</string>
+	<key>shortcut</key><string>:four_leaf_clover:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f341;</string>
+	<key>shortcut</key><string>:maple_leaf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f342;</string>
+	<key>shortcut</key><string>:fallen_leaf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f343;</string>
+	<key>shortcut</key><string>:leaves:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f344;</string>
+	<key>shortcut</key><string>:mushroom:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f345;</string>
+	<key>shortcut</key><string>:tomato:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f346;</string>
+	<key>shortcut</key><string>:eggplant:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f347;</string>
+	<key>shortcut</key><string>:grapes:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f348;</string>
+	<key>shortcut</key><string>:melon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f349;</string>
+	<key>shortcut</key><string>:watermelon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f34a;</string>
+	<key>shortcut</key><string>:tangerine:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f34b;</string>
+	<key>shortcut</key><string>:lemon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f34c;</string>
+	<key>shortcut</key><string>:banana:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f34d;</string>
+	<key>shortcut</key><string>:pineapple:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f34e;</string>
+	<key>shortcut</key><string>:apple:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f34f;</string>
+	<key>shortcut</key><string>:green_apple:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f350;</string>
+	<key>shortcut</key><string>:pear:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f351;</string>
+	<key>shortcut</key><string>:peach:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f352;</string>
+	<key>shortcut</key><string>:cherries:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f353;</string>
+	<key>shortcut</key><string>:strawberry:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f354;</string>
+	<key>shortcut</key><string>:hamburger:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f355;</string>
+	<key>shortcut</key><string>:pizza:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f356;</string>
+	<key>shortcut</key><string>:meat_on_bone:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f357;</string>
+	<key>shortcut</key><string>:poultry_leg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f358;</string>
+	<key>shortcut</key><string>:rice_cracker:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f359;</string>
+	<key>shortcut</key><string>:rice_ball:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f35a;</string>
+	<key>shortcut</key><string>:rice:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f35b;</string>
+	<key>shortcut</key><string>:curry:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f35c;</string>
+	<key>shortcut</key><string>:ramen:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f35d;</string>
+	<key>shortcut</key><string>:spaghetti:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f35e;</string>
+	<key>shortcut</key><string>:bread:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f35f;</string>
+	<key>shortcut</key><string>:fries:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f360;</string>
+	<key>shortcut</key><string>:sweet_potato:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f361;</string>
+	<key>shortcut</key><string>:dango:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f362;</string>
+	<key>shortcut</key><string>:oden:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f363;</string>
+	<key>shortcut</key><string>:sushi:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f364;</string>
+	<key>shortcut</key><string>:fried_shrimp:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f365;</string>
+	<key>shortcut</key><string>:fish_cake:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f366;</string>
+	<key>shortcut</key><string>:icecream:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f367;</string>
+	<key>shortcut</key><string>:shaved_ice:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f368;</string>
+	<key>shortcut</key><string>:ice_cream:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f369;</string>
+	<key>shortcut</key><string>:doughnut:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f36a;</string>
+	<key>shortcut</key><string>:cookie:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f36b;</string>
+	<key>shortcut</key><string>:chocolate_bar:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f36c;</string>
+	<key>shortcut</key><string>:candy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f36d;</string>
+	<key>shortcut</key><string>:lollipop:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f36e;</string>
+	<key>shortcut</key><string>:custard:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f36e;</string>
+	<key>shortcut</key><string>:pudding:|:flan:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f36f;</string>
+	<key>shortcut</key><string>:honey_pot:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f370;</string>
+	<key>shortcut</key><string>:cake:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f371;</string>
+	<key>shortcut</key><string>:bento:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f372;</string>
+	<key>shortcut</key><string>:stew:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f373;</string>
+	<key>shortcut</key><string>:cooking:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f374;</string>
+	<key>shortcut</key><string>:fork_and_knife:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f375;</string>
+	<key>shortcut</key><string>:tea:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f376;</string>
+	<key>shortcut</key><string>:sake:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f377;</string>
+	<key>shortcut</key><string>:wine_glass:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f378;</string>
+	<key>shortcut</key><string>:cocktail:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f379;</string>
+	<key>shortcut</key><string>:tropical_drink:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f37a;</string>
+	<key>shortcut</key><string>:beer:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f37b;</string>
+	<key>shortcut</key><string>:beers:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f37c;</string>
+	<key>shortcut</key><string>:baby_bottle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f37d;</string>
+	<key>shortcut</key><string>:fork_knife_plate:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f37d;</string>
+	<key>shortcut</key><string>:fork_and_knife_with_plate:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f37e;</string>
+	<key>shortcut</key><string>:champagne:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f37e;</string>
+	<key>shortcut</key><string>:bottle_with_popping_cork:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f37f;</string>
+	<key>shortcut</key><string>:popcorn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f380;</string>
+	<key>shortcut</key><string>:ribbon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f381;</string>
+	<key>shortcut</key><string>:gift:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f382;</string>
+	<key>shortcut</key><string>:birthday:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f383;</string>
+	<key>shortcut</key><string>:jack_o_lantern:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f384;</string>
+	<key>shortcut</key><string>:christmas_tree:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f385;</string>
+	<key>shortcut</key><string>:santa:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f385;&#x1f3fb;</string>
+	<key>shortcut</key><string>:santa_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f385;&#x1f3fc;</string>
+	<key>shortcut</key><string>:santa_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f385;&#x1f3fd;</string>
+	<key>shortcut</key><string>:santa_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f385;&#x1f3fe;</string>
+	<key>shortcut</key><string>:santa_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f385;&#x1f3ff;</string>
+	<key>shortcut</key><string>:santa_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f386;</string>
+	<key>shortcut</key><string>:fireworks:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f387;</string>
+	<key>shortcut</key><string>:sparkler:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f388;</string>
+	<key>shortcut</key><string>:balloon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f389;</string>
+	<key>shortcut</key><string>:tada:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f38a;</string>
+	<key>shortcut</key><string>:confetti_ball:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f38b;</string>
+	<key>shortcut</key><string>:tanabata_tree:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f38c;</string>
+	<key>shortcut</key><string>:crossed_flags:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f38d;</string>
+	<key>shortcut</key><string>:bamboo:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f38e;</string>
+	<key>shortcut</key><string>:dolls:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f38f;</string>
+	<key>shortcut</key><string>:flags:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f390;</string>
+	<key>shortcut</key><string>:wind_chime:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f391;</string>
+	<key>shortcut</key><string>:rice_scene:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f392;</string>
+	<key>shortcut</key><string>:school_satchel:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f393;</string>
+	<key>shortcut</key><string>:mortar_board:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f396;</string>
+	<key>shortcut</key><string>:military_medal:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f397;</string>
+	<key>shortcut</key><string>:reminder_ribbon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f399;</string>
+	<key>shortcut</key><string>:microphone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f399;</string>
+	<key>shortcut</key><string>:studio_microphone:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f39a;</string>
+	<key>shortcut</key><string>:level_slider:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f39b;</string>
+	<key>shortcut</key><string>:control_knobs:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f39e;</string>
+	<key>shortcut</key><string>:film_frames:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f39f;</string>
+	<key>shortcut</key><string>:tickets:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f39f;</string>
+	<key>shortcut</key><string>:admission_tickets:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3a0;</string>
+	<key>shortcut</key><string>:carousel_horse:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3a1;</string>
+	<key>shortcut</key><string>:ferris_wheel:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3a2;</string>
+	<key>shortcut</key><string>:roller_coaster:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3a3;</string>
+	<key>shortcut</key><string>:fishing_pole_and_fish:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3a4;</string>
+	<key>shortcut</key><string>:microphone:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3a5;</string>
+	<key>shortcut</key><string>:movie_camera:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3a6;</string>
+	<key>shortcut</key><string>:cinema:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3a7;</string>
+	<key>shortcut</key><string>:headphones:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3a8;</string>
+	<key>shortcut</key><string>:art:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3a9;</string>
+	<key>shortcut</key><string>:tophat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3aa;</string>
+	<key>shortcut</key><string>:circus_tent:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ab;</string>
+	<key>shortcut</key><string>:ticket:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ac;</string>
+	<key>shortcut</key><string>:clapper:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ad;</string>
+	<key>shortcut</key><string>:performing_arts:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ae;</string>
+	<key>shortcut</key><string>:video_game:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3af;</string>
+	<key>shortcut</key><string>:dart:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3b0;</string>
+	<key>shortcut</key><string>:slot_machine:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3b1;</string>
+	<key>shortcut</key><string>:8ball:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3b2;</string>
+	<key>shortcut</key><string>:game_die:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3b3;</string>
+	<key>shortcut</key><string>:bowling:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3b4;</string>
+	<key>shortcut</key><string>:flower_playing_cards:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3b5;</string>
+	<key>shortcut</key><string>:musical_note:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3b6;</string>
+	<key>shortcut</key><string>:notes:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3b7;</string>
+	<key>shortcut</key><string>:saxophone:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3b8;</string>
+	<key>shortcut</key><string>:guitar:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3b9;</string>
+	<key>shortcut</key><string>:musical_keyboard:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ba;</string>
+	<key>shortcut</key><string>:trumpet:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3bb;</string>
+	<key>shortcut</key><string>:violin:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3bc;</string>
+	<key>shortcut</key><string>:musical_score:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3bd;</string>
+	<key>shortcut</key><string>:running_shirt_with_sash:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3be;</string>
+	<key>shortcut</key><string>:tennis:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3bf;</string>
+	<key>shortcut</key><string>:ski:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c0;</string>
+	<key>shortcut</key><string>:basketball:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c1;</string>
+	<key>shortcut</key><string>:checkered_flag:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c2;</string>
+	<key>shortcut</key><string>:snowboarder:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c3;</string>
+	<key>shortcut</key><string>:runner:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c3;&#x1f3fb;</string>
+	<key>shortcut</key><string>:runner_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c3;&#x1f3fc;</string>
+	<key>shortcut</key><string>:runner_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c3;&#x1f3fd;</string>
+	<key>shortcut</key><string>:runner_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c3;&#x1f3fe;</string>
+	<key>shortcut</key><string>:runner_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c3;&#x1f3ff;</string>
+	<key>shortcut</key><string>:runner_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c4;</string>
+	<key>shortcut</key><string>:surfer:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c4;&#x1f3fb;</string>
+	<key>shortcut</key><string>:surfer_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c4;&#x1f3fc;</string>
+	<key>shortcut</key><string>:surfer_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c4;&#x1f3fd;</string>
+	<key>shortcut</key><string>:surfer_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c4;&#x1f3fe;</string>
+	<key>shortcut</key><string>:surfer_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c4;&#x1f3ff;</string>
+	<key>shortcut</key><string>:surfer_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c5;</string>
+	<key>shortcut</key><string>:medal:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c5;</string>
+	<key>shortcut</key><string>:sports_medal:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c6;</string>
+	<key>shortcut</key><string>:trophy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c7;</string>
+	<key>shortcut</key><string>:horse_racing:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c7;&#x1f3fb;</string>
+	<key>shortcut</key><string>:horse_racing_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c7;&#x1f3fc;</string>
+	<key>shortcut</key><string>:horse_racing_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c7;&#x1f3fd;</string>
+	<key>shortcut</key><string>:horse_racing_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c7;&#x1f3fe;</string>
+	<key>shortcut</key><string>:horse_racing_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c7;&#x1f3ff;</string>
+	<key>shortcut</key><string>:horse_racing_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c8;</string>
+	<key>shortcut</key><string>:football:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3c9;</string>
+	<key>shortcut</key><string>:rugby_football:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ca;</string>
+	<key>shortcut</key><string>:swimmer:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ca;&#x1f3fb;</string>
+	<key>shortcut</key><string>:swimmer_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ca;&#x1f3fc;</string>
+	<key>shortcut</key><string>:swimmer_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ca;&#x1f3fd;</string>
+	<key>shortcut</key><string>:swimmer_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ca;&#x1f3fe;</string>
+	<key>shortcut</key><string>:swimmer_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ca;&#x1f3ff;</string>
+	<key>shortcut</key><string>:swimmer_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3cb;</string>
+	<key>shortcut</key><string>:lifter:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3cb;</string>
+	<key>shortcut</key><string>:weight_lifter:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3cb;&#x1f3fb;</string>
+	<key>shortcut</key><string>:lifter_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3cb;&#x1f3fb;</string>
+	<key>shortcut</key><string>:weight_lifter_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3cb;&#x1f3fc;</string>
+	<key>shortcut</key><string>:lifter_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3cb;&#x1f3fc;</string>
+	<key>shortcut</key><string>:weight_lifter_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3cb;&#x1f3fd;</string>
+	<key>shortcut</key><string>:lifter_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3cb;&#x1f3fd;</string>
+	<key>shortcut</key><string>:weight_lifter_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3cb;&#x1f3fe;</string>
+	<key>shortcut</key><string>:lifter_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3cb;&#x1f3fe;</string>
+	<key>shortcut</key><string>:weight_lifter_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3cb;&#x1f3ff;</string>
+	<key>shortcut</key><string>:lifter_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3cb;&#x1f3ff;</string>
+	<key>shortcut</key><string>:weight_lifter_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3cc;</string>
+	<key>shortcut</key><string>:golfer:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3cd;</string>
+	<key>shortcut</key><string>:motorcycle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3cd;</string>
+	<key>shortcut</key><string>:racing_motorcycle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ce;</string>
+	<key>shortcut</key><string>:race_car:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ce;</string>
+	<key>shortcut</key><string>:racing_car:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3cf;</string>
+	<key>shortcut</key><string>:cricket:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3cf;</string>
+	<key>shortcut</key><string>:cricket_bat_ball:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3d0;</string>
+	<key>shortcut</key><string>:volleyball:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3d1;</string>
+	<key>shortcut</key><string>:field_hockey:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3d2;</string>
+	<key>shortcut</key><string>:hockey:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3d3;</string>
+	<key>shortcut</key><string>:ping_pong:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3d3;</string>
+	<key>shortcut</key><string>:table_tennis:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3d4;</string>
+	<key>shortcut</key><string>:mountain_snow:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3d4;</string>
+	<key>shortcut</key><string>:snow_capped_mountain:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3d5;</string>
+	<key>shortcut</key><string>:camping:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3d6;</string>
+	<key>shortcut</key><string>:beach:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3d6;</string>
+	<key>shortcut</key><string>:beach_with_umbrella:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3d7;</string>
+	<key>shortcut</key><string>:construction_site:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3d7;</string>
+	<key>shortcut</key><string>:building_construction:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3d8;</string>
+	<key>shortcut</key><string>:homes:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3d8;</string>
+	<key>shortcut</key><string>:house_buildings:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3d9;</string>
+	<key>shortcut</key><string>:cityscape:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3da;</string>
+	<key>shortcut</key><string>:house_abandoned:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3da;</string>
+	<key>shortcut</key><string>:derelict_house_building:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3db;</string>
+	<key>shortcut</key><string>:classical_building:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3dc;</string>
+	<key>shortcut</key><string>:desert:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3dd;</string>
+	<key>shortcut</key><string>:island:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3dd;</string>
+	<key>shortcut</key><string>:desert_island:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3de;</string>
+	<key>shortcut</key><string>:park:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3de;</string>
+	<key>shortcut</key><string>:national_park:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3df;</string>
+	<key>shortcut</key><string>:stadium:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3e0;</string>
+	<key>shortcut</key><string>:house:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3e1;</string>
+	<key>shortcut</key><string>:house_with_garden:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3e2;</string>
+	<key>shortcut</key><string>:office:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3e3;</string>
+	<key>shortcut</key><string>:post_office:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3e4;</string>
+	<key>shortcut</key><string>:european_post_office:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3e5;</string>
+	<key>shortcut</key><string>:hospital:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3e6;</string>
+	<key>shortcut</key><string>:bank:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3e7;</string>
+	<key>shortcut</key><string>:atm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3e8;</string>
+	<key>shortcut</key><string>:hotel:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3e9;</string>
+	<key>shortcut</key><string>:love_hotel:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ea;</string>
+	<key>shortcut</key><string>:convenience_store:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3eb;</string>
+	<key>shortcut</key><string>:school:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ec;</string>
+	<key>shortcut</key><string>:department_store:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ed;</string>
+	<key>shortcut</key><string>:factory:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ee;</string>
+	<key>shortcut</key><string>:izakaya_lantern:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ef;</string>
+	<key>shortcut</key><string>:japanese_castle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3f0;</string>
+	<key>shortcut</key><string>:european_castle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3f3;</string>
+	<key>shortcut</key><string>:flag_white:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3f3;</string>
+	<key>shortcut</key><string>:waving_white_flag:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3f3;&#x1f308;</string>
+	<key>shortcut</key><string>:gay_pride_flag:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3f3;&#x1f308;</string>
+	<key>shortcut</key><string>:rainbow_flag:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3f4;</string>
+	<key>shortcut</key><string>:flag_black:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3f4;</string>
+	<key>shortcut</key><string>:waving_black_flag:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3f5;</string>
+	<key>shortcut</key><string>:rosette:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3f7;</string>
+	<key>shortcut</key><string>:label:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3f8;</string>
+	<key>shortcut</key><string>:badminton:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3f9;</string>
+	<key>shortcut</key><string>:bow_and_arrow:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3f9;</string>
+	<key>shortcut</key><string>:archery:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3fa;</string>
+	<key>shortcut</key><string>:amphora:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3fb;</string>
+	<key>shortcut</key><string>:tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3fc;</string>
+	<key>shortcut</key><string>:tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3fd;</string>
+	<key>shortcut</key><string>:tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3fe;</string>
+	<key>shortcut</key><string>:tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f3ff;</string>
+	<key>shortcut</key><string>:tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f400;</string>
+	<key>shortcut</key><string>:rat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f401;</string>
+	<key>shortcut</key><string>:mouse2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f402;</string>
+	<key>shortcut</key><string>:ox:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f403;</string>
+	<key>shortcut</key><string>:water_buffalo:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f404;</string>
+	<key>shortcut</key><string>:cow2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f405;</string>
+	<key>shortcut</key><string>:tiger2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f406;</string>
+	<key>shortcut</key><string>:leopard:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f407;</string>
+	<key>shortcut</key><string>:rabbit2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f408;</string>
+	<key>shortcut</key><string>:cat2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f409;</string>
+	<key>shortcut</key><string>:dragon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f40a;</string>
+	<key>shortcut</key><string>:crocodile:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f40b;</string>
+	<key>shortcut</key><string>:whale2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f40c;</string>
+	<key>shortcut</key><string>:snail:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f40d;</string>
+	<key>shortcut</key><string>:snake:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f40e;</string>
+	<key>shortcut</key><string>:racehorse:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f40f;</string>
+	<key>shortcut</key><string>:ram:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f410;</string>
+	<key>shortcut</key><string>:goat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f411;</string>
+	<key>shortcut</key><string>:sheep:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f412;</string>
+	<key>shortcut</key><string>:monkey:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f413;</string>
+	<key>shortcut</key><string>:rooster:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f414;</string>
+	<key>shortcut</key><string>:chicken:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f415;</string>
+	<key>shortcut</key><string>:dog2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f416;</string>
+	<key>shortcut</key><string>:pig2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f417;</string>
+	<key>shortcut</key><string>:boar:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f418;</string>
+	<key>shortcut</key><string>:elephant:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f419;</string>
+	<key>shortcut</key><string>:octopus:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f41a;</string>
+	<key>shortcut</key><string>:shell:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f41b;</string>
+	<key>shortcut</key><string>:bug:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f41c;</string>
+	<key>shortcut</key><string>:ant:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f41d;</string>
+	<key>shortcut</key><string>:bee:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f41e;</string>
+	<key>shortcut</key><string>:beetle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f41f;</string>
+	<key>shortcut</key><string>:fish:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f420;</string>
+	<key>shortcut</key><string>:tropical_fish:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f421;</string>
+	<key>shortcut</key><string>:blowfish:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f422;</string>
+	<key>shortcut</key><string>:turtle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f423;</string>
+	<key>shortcut</key><string>:hatching_chick:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f424;</string>
+	<key>shortcut</key><string>:baby_chick:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f425;</string>
+	<key>shortcut</key><string>:hatched_chick:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f426;</string>
+	<key>shortcut</key><string>:bird:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f427;</string>
+	<key>shortcut</key><string>:penguin:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f428;</string>
+	<key>shortcut</key><string>:koala:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f429;</string>
+	<key>shortcut</key><string>:poodle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f42a;</string>
+	<key>shortcut</key><string>:dromedary_camel:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f42b;</string>
+	<key>shortcut</key><string>:camel:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f42c;</string>
+	<key>shortcut</key><string>:dolphin:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f42d;</string>
+	<key>shortcut</key><string>:mouse:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f42e;</string>
+	<key>shortcut</key><string>:cow:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f42f;</string>
+	<key>shortcut</key><string>:tiger:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f430;</string>
+	<key>shortcut</key><string>:rabbit:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f431;</string>
+	<key>shortcut</key><string>:cat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f432;</string>
+	<key>shortcut</key><string>:dragon_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f433;</string>
+	<key>shortcut</key><string>:whale:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f434;</string>
+	<key>shortcut</key><string>:horse:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f435;</string>
+	<key>shortcut</key><string>:monkey_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f436;</string>
+	<key>shortcut</key><string>:dog:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f437;</string>
+	<key>shortcut</key><string>:pig:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f438;</string>
+	<key>shortcut</key><string>:frog:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f439;</string>
+	<key>shortcut</key><string>:hamster:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f43a;</string>
+	<key>shortcut</key><string>:wolf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f43b;</string>
+	<key>shortcut</key><string>:bear:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f43c;</string>
+	<key>shortcut</key><string>:panda_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f43d;</string>
+	<key>shortcut</key><string>:pig_nose:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f43e;</string>
+	<key>shortcut</key><string>:feet:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f43e;</string>
+	<key>shortcut</key><string>:paw_prints:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f43f;</string>
+	<key>shortcut</key><string>:chipmunk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f440;</string>
+	<key>shortcut</key><string>:eyes:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f441;</string>
+	<key>shortcut</key><string>:eye:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f441;&#x1f5e8;</string>
+	<key>shortcut</key><string>:eye_in_speech_bubble:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f442;</string>
+	<key>shortcut</key><string>:ear:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f442;&#x1f3fb;</string>
+	<key>shortcut</key><string>:ear_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f442;&#x1f3fc;</string>
+	<key>shortcut</key><string>:ear_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f442;&#x1f3fd;</string>
+	<key>shortcut</key><string>:ear_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f442;&#x1f3fe;</string>
+	<key>shortcut</key><string>:ear_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f442;&#x1f3ff;</string>
+	<key>shortcut</key><string>:ear_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f443;</string>
+	<key>shortcut</key><string>:nose:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f443;&#x1f3fb;</string>
+	<key>shortcut</key><string>:nose_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f443;&#x1f3fc;</string>
+	<key>shortcut</key><string>:nose_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f443;&#x1f3fd;</string>
+	<key>shortcut</key><string>:nose_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f443;&#x1f3fe;</string>
+	<key>shortcut</key><string>:nose_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f443;&#x1f3ff;</string>
+	<key>shortcut</key><string>:nose_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f444;</string>
+	<key>shortcut</key><string>:lips:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f445;</string>
+	<key>shortcut</key><string>:tongue:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f446;</string>
+	<key>shortcut</key><string>:point_up_2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f446;&#x1f3fb;</string>
+	<key>shortcut</key><string>:point_up_2_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f446;&#x1f3fc;</string>
+	<key>shortcut</key><string>:point_up_2_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f446;&#x1f3fd;</string>
+	<key>shortcut</key><string>:point_up_2_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f446;&#x1f3fe;</string>
+	<key>shortcut</key><string>:point_up_2_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f446;&#x1f3ff;</string>
+	<key>shortcut</key><string>:point_up_2_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f447;</string>
+	<key>shortcut</key><string>:point_down:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f447;&#x1f3fb;</string>
+	<key>shortcut</key><string>:point_down_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f447;&#x1f3fc;</string>
+	<key>shortcut</key><string>:point_down_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f447;&#x1f3fd;</string>
+	<key>shortcut</key><string>:point_down_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f447;&#x1f3fe;</string>
+	<key>shortcut</key><string>:point_down_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f447;&#x1f3ff;</string>
+	<key>shortcut</key><string>:point_down_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f448;</string>
+	<key>shortcut</key><string>:point_left:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f448;&#x1f3fb;</string>
+	<key>shortcut</key><string>:point_left_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f448;&#x1f3fc;</string>
+	<key>shortcut</key><string>:point_left_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f448;&#x1f3fd;</string>
+	<key>shortcut</key><string>:point_left_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f448;&#x1f3fe;</string>
+	<key>shortcut</key><string>:point_left_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f448;&#x1f3ff;</string>
+	<key>shortcut</key><string>:point_left_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f449;</string>
+	<key>shortcut</key><string>:point_right:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f449;&#x1f3fb;</string>
+	<key>shortcut</key><string>:point_right_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f449;&#x1f3fc;</string>
+	<key>shortcut</key><string>:point_right_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f449;&#x1f3fd;</string>
+	<key>shortcut</key><string>:point_right_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f449;&#x1f3fe;</string>
+	<key>shortcut</key><string>:point_right_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f449;&#x1f3ff;</string>
+	<key>shortcut</key><string>:point_right_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44a;</string>
+	<key>shortcut</key><string>:punch:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44a;&#x1f3fb;</string>
+	<key>shortcut</key><string>:punch_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44a;&#x1f3fc;</string>
+	<key>shortcut</key><string>:punch_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44a;&#x1f3fd;</string>
+	<key>shortcut</key><string>:punch_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44a;&#x1f3fe;</string>
+	<key>shortcut</key><string>:punch_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44a;&#x1f3ff;</string>
+	<key>shortcut</key><string>:punch_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44b;</string>
+	<key>shortcut</key><string>:wave:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44b;&#x1f3fb;</string>
+	<key>shortcut</key><string>:wave_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44b;&#x1f3fc;</string>
+	<key>shortcut</key><string>:wave_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44b;&#x1f3fd;</string>
+	<key>shortcut</key><string>:wave_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44b;&#x1f3fe;</string>
+	<key>shortcut</key><string>:wave_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44b;&#x1f3ff;</string>
+	<key>shortcut</key><string>:wave_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44c;</string>
+	<key>shortcut</key><string>:ok_hand:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44c;&#x1f3fb;</string>
+	<key>shortcut</key><string>:ok_hand_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44c;&#x1f3fc;</string>
+	<key>shortcut</key><string>:ok_hand_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44c;&#x1f3fd;</string>
+	<key>shortcut</key><string>:ok_hand_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44c;&#x1f3fe;</string>
+	<key>shortcut</key><string>:ok_hand_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44c;&#x1f3ff;</string>
+	<key>shortcut</key><string>:ok_hand_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44d;</string>
+	<key>shortcut</key><string>:thumbsup:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44d;</string>
+	<key>shortcut</key><string>:+1:|:thumbup:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44d;&#x1f3fb;</string>
+	<key>shortcut</key><string>:thumbsup_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44d;&#x1f3fb;</string>
+	<key>shortcut</key><string>:+1_tone1:|:thumbup_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44d;&#x1f3fc;</string>
+	<key>shortcut</key><string>:thumbsup_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44d;&#x1f3fc;</string>
+	<key>shortcut</key><string>:+1_tone2:|:thumbup_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44d;&#x1f3fd;</string>
+	<key>shortcut</key><string>:thumbsup_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44d;&#x1f3fd;</string>
+	<key>shortcut</key><string>:+1_tone3:|:thumbup_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44d;&#x1f3fe;</string>
+	<key>shortcut</key><string>:thumbsup_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44d;&#x1f3fe;</string>
+	<key>shortcut</key><string>:+1_tone4:|:thumbup_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44d;&#x1f3ff;</string>
+	<key>shortcut</key><string>:thumbsup_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44d;&#x1f3ff;</string>
+	<key>shortcut</key><string>:+1_tone5:|:thumbup_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44e;</string>
+	<key>shortcut</key><string>:thumbsdown:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44e;</string>
+	<key>shortcut</key><string>:-1:|:thumbdown:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44e;&#x1f3fb;</string>
+	<key>shortcut</key><string>:thumbsdown_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44e;&#x1f3fb;</string>
+	<key>shortcut</key><string>:-1_tone1:|:thumbdown_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44e;&#x1f3fc;</string>
+	<key>shortcut</key><string>:thumbsdown_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44e;&#x1f3fc;</string>
+	<key>shortcut</key><string>:-1_tone2:|:thumbdown_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44e;&#x1f3fd;</string>
+	<key>shortcut</key><string>:thumbsdown_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44e;&#x1f3fd;</string>
+	<key>shortcut</key><string>:-1_tone3:|:thumbdown_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44e;&#x1f3fe;</string>
+	<key>shortcut</key><string>:thumbsdown_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44e;&#x1f3fe;</string>
+	<key>shortcut</key><string>:-1_tone4:|:thumbdown_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44e;&#x1f3ff;</string>
+	<key>shortcut</key><string>:thumbsdown_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44e;&#x1f3ff;</string>
+	<key>shortcut</key><string>:-1_tone5:|:thumbdown_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44f;</string>
+	<key>shortcut</key><string>:clap:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44f;&#x1f3fb;</string>
+	<key>shortcut</key><string>:clap_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44f;&#x1f3fc;</string>
+	<key>shortcut</key><string>:clap_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44f;&#x1f3fd;</string>
+	<key>shortcut</key><string>:clap_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44f;&#x1f3fe;</string>
+	<key>shortcut</key><string>:clap_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f44f;&#x1f3ff;</string>
+	<key>shortcut</key><string>:clap_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f450;</string>
+	<key>shortcut</key><string>:open_hands:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f450;&#x1f3fb;</string>
+	<key>shortcut</key><string>:open_hands_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f450;&#x1f3fc;</string>
+	<key>shortcut</key><string>:open_hands_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f450;&#x1f3fd;</string>
+	<key>shortcut</key><string>:open_hands_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f450;&#x1f3fe;</string>
+	<key>shortcut</key><string>:open_hands_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f450;&#x1f3ff;</string>
+	<key>shortcut</key><string>:open_hands_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f451;</string>
+	<key>shortcut</key><string>:crown:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f452;</string>
+	<key>shortcut</key><string>:womans_hat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f453;</string>
+	<key>shortcut</key><string>:eyeglasses:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f454;</string>
+	<key>shortcut</key><string>:necktie:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f455;</string>
+	<key>shortcut</key><string>:shirt:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f456;</string>
+	<key>shortcut</key><string>:jeans:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f457;</string>
+	<key>shortcut</key><string>:dress:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f458;</string>
+	<key>shortcut</key><string>:kimono:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f459;</string>
+	<key>shortcut</key><string>:bikini:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f45a;</string>
+	<key>shortcut</key><string>:womans_clothes:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f45b;</string>
+	<key>shortcut</key><string>:purse:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f45c;</string>
+	<key>shortcut</key><string>:handbag:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f45d;</string>
+	<key>shortcut</key><string>:pouch:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f45e;</string>
+	<key>shortcut</key><string>:mans_shoe:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f45f;</string>
+	<key>shortcut</key><string>:athletic_shoe:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f460;</string>
+	<key>shortcut</key><string>:high_heel:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f461;</string>
+	<key>shortcut</key><string>:sandal:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f462;</string>
+	<key>shortcut</key><string>:boot:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f463;</string>
+	<key>shortcut</key><string>:footprints:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f464;</string>
+	<key>shortcut</key><string>:bust_in_silhouette:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f465;</string>
+	<key>shortcut</key><string>:busts_in_silhouette:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f466;</string>
+	<key>shortcut</key><string>:boy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f466;&#x1f3fb;</string>
+	<key>shortcut</key><string>:boy_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f466;&#x1f3fc;</string>
+	<key>shortcut</key><string>:boy_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f466;&#x1f3fd;</string>
+	<key>shortcut</key><string>:boy_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f466;&#x1f3fe;</string>
+	<key>shortcut</key><string>:boy_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f466;&#x1f3ff;</string>
+	<key>shortcut</key><string>:boy_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f467;</string>
+	<key>shortcut</key><string>:girl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f467;&#x1f3fb;</string>
+	<key>shortcut</key><string>:girl_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f467;&#x1f3fc;</string>
+	<key>shortcut</key><string>:girl_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f467;&#x1f3fd;</string>
+	<key>shortcut</key><string>:girl_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f467;&#x1f3fe;</string>
+	<key>shortcut</key><string>:girl_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f467;&#x1f3ff;</string>
+	<key>shortcut</key><string>:girl_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;</string>
+	<key>shortcut</key><string>:man:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x1f3fb;</string>
+	<key>shortcut</key><string>:man_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x1f3fc;</string>
+	<key>shortcut</key><string>:man_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x1f3fd;</string>
+	<key>shortcut</key><string>:man_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x1f3fe;</string>
+	<key>shortcut</key><string>:man_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x1f3ff;</string>
+	<key>shortcut</key><string>:man_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x1f468;&#x1f466;</string>
+	<key>shortcut</key><string>:family_mmb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x1f468;&#x1f466;&#x1f466;</string>
+	<key>shortcut</key><string>:family_mmbb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x1f468;&#x1f467;</string>
+	<key>shortcut</key><string>:family_mmg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x1f468;&#x1f467;&#x1f466;</string>
+	<key>shortcut</key><string>:family_mmgb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x1f468;&#x1f467;&#x1f467;</string>
+	<key>shortcut</key><string>:family_mmgg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x1f469;&#x1f466;&#x1f466;</string>
+	<key>shortcut</key><string>:family_mwbb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x1f469;&#x1f467;</string>
+	<key>shortcut</key><string>:family_mwg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x1f469;&#x1f467;&#x1f466;</string>
+	<key>shortcut</key><string>:family_mwgb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x1f469;&#x1f467;&#x1f467;</string>
+	<key>shortcut</key><string>:family_mwgg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x2764;&#x1f468;</string>
+	<key>shortcut</key><string>:couple_mm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x2764;&#x1f468;</string>
+	<key>shortcut</key><string>:couple_with_heart_mm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x2764;&#x1f48b;&#x1f468;</string>
+	<key>shortcut</key><string>:kiss_mm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f468;&#x2764;&#x1f48b;&#x1f468;</string>
+	<key>shortcut</key><string>:couplekiss_mm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f469;</string>
+	<key>shortcut</key><string>:woman:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f469;&#x1f3fb;</string>
+	<key>shortcut</key><string>:woman_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f469;&#x1f3fc;</string>
+	<key>shortcut</key><string>:woman_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f469;&#x1f3fd;</string>
+	<key>shortcut</key><string>:woman_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f469;&#x1f3fe;</string>
+	<key>shortcut</key><string>:woman_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f469;&#x1f3ff;</string>
+	<key>shortcut</key><string>:woman_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f469;&#x1f469;&#x1f466;</string>
+	<key>shortcut</key><string>:family_wwb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f469;&#x1f469;&#x1f466;&#x1f466;</string>
+	<key>shortcut</key><string>:family_wwbb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f469;&#x1f469;&#x1f467;</string>
+	<key>shortcut</key><string>:family_wwg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f469;&#x1f469;&#x1f467;&#x1f466;</string>
+	<key>shortcut</key><string>:family_wwgb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f469;&#x1f469;&#x1f467;&#x1f467;</string>
+	<key>shortcut</key><string>:family_wwgg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f469;&#x2764;&#x1f469;</string>
+	<key>shortcut</key><string>:couple_ww:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f469;&#x2764;&#x1f469;</string>
+	<key>shortcut</key><string>:couple_with_heart_ww:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f469;&#x2764;&#x1f48b;&#x1f469;</string>
+	<key>shortcut</key><string>:kiss_ww:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f469;&#x2764;&#x1f48b;&#x1f469;</string>
+	<key>shortcut</key><string>:couplekiss_ww:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f46a;</string>
+	<key>shortcut</key><string>:family:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f46b;</string>
+	<key>shortcut</key><string>:couple:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f46c;</string>
+	<key>shortcut</key><string>:two_men_holding_hands:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f46d;</string>
+	<key>shortcut</key><string>:two_women_holding_hands:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f46e;</string>
+	<key>shortcut</key><string>:cop:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f46e;&#x1f3fb;</string>
+	<key>shortcut</key><string>:cop_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f46e;&#x1f3fc;</string>
+	<key>shortcut</key><string>:cop_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f46e;&#x1f3fd;</string>
+	<key>shortcut</key><string>:cop_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f46e;&#x1f3fe;</string>
+	<key>shortcut</key><string>:cop_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f46e;&#x1f3ff;</string>
+	<key>shortcut</key><string>:cop_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f46f;</string>
+	<key>shortcut</key><string>:dancers:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f470;</string>
+	<key>shortcut</key><string>:bride_with_veil:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f470;&#x1f3fb;</string>
+	<key>shortcut</key><string>:bride_with_veil_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f470;&#x1f3fc;</string>
+	<key>shortcut</key><string>:bride_with_veil_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f470;&#x1f3fd;</string>
+	<key>shortcut</key><string>:bride_with_veil_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f470;&#x1f3fe;</string>
+	<key>shortcut</key><string>:bride_with_veil_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f470;&#x1f3ff;</string>
+	<key>shortcut</key><string>:bride_with_veil_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f471;</string>
+	<key>shortcut</key><string>:person_with_blond_hair:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f471;&#x1f3fb;</string>
+	<key>shortcut</key><string>:person_with_blond_hair_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f471;&#x1f3fc;</string>
+	<key>shortcut</key><string>:person_with_blond_hair_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f471;&#x1f3fd;</string>
+	<key>shortcut</key><string>:person_with_blond_hair_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f471;&#x1f3fe;</string>
+	<key>shortcut</key><string>:person_with_blond_hair_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f471;&#x1f3ff;</string>
+	<key>shortcut</key><string>:person_with_blond_hair_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f472;</string>
+	<key>shortcut</key><string>:man_with_gua_pi_mao:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f472;&#x1f3fb;</string>
+	<key>shortcut</key><string>:man_with_gua_pi_mao_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f472;&#x1f3fc;</string>
+	<key>shortcut</key><string>:man_with_gua_pi_mao_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f472;&#x1f3fd;</string>
+	<key>shortcut</key><string>:man_with_gua_pi_mao_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f472;&#x1f3fe;</string>
+	<key>shortcut</key><string>:man_with_gua_pi_mao_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f472;&#x1f3ff;</string>
+	<key>shortcut</key><string>:man_with_gua_pi_mao_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f473;</string>
+	<key>shortcut</key><string>:man_with_turban:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f473;&#x1f3fb;</string>
+	<key>shortcut</key><string>:man_with_turban_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f473;&#x1f3fc;</string>
+	<key>shortcut</key><string>:man_with_turban_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f473;&#x1f3fd;</string>
+	<key>shortcut</key><string>:man_with_turban_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f473;&#x1f3fe;</string>
+	<key>shortcut</key><string>:man_with_turban_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f473;&#x1f3ff;</string>
+	<key>shortcut</key><string>:man_with_turban_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f474;</string>
+	<key>shortcut</key><string>:older_man:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f474;&#x1f3fb;</string>
+	<key>shortcut</key><string>:older_man_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f474;&#x1f3fc;</string>
+	<key>shortcut</key><string>:older_man_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f474;&#x1f3fd;</string>
+	<key>shortcut</key><string>:older_man_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f474;&#x1f3fe;</string>
+	<key>shortcut</key><string>:older_man_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f474;&#x1f3ff;</string>
+	<key>shortcut</key><string>:older_man_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f475;</string>
+	<key>shortcut</key><string>:older_woman:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f475;</string>
+	<key>shortcut</key><string>:grandma:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f475;&#x1f3fb;</string>
+	<key>shortcut</key><string>:older_woman_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f475;&#x1f3fb;</string>
+	<key>shortcut</key><string>:grandma_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f475;&#x1f3fc;</string>
+	<key>shortcut</key><string>:older_woman_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f475;&#x1f3fc;</string>
+	<key>shortcut</key><string>:grandma_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f475;&#x1f3fd;</string>
+	<key>shortcut</key><string>:older_woman_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f475;&#x1f3fd;</string>
+	<key>shortcut</key><string>:grandma_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f475;&#x1f3fe;</string>
+	<key>shortcut</key><string>:older_woman_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f475;&#x1f3fe;</string>
+	<key>shortcut</key><string>:grandma_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f475;&#x1f3ff;</string>
+	<key>shortcut</key><string>:older_woman_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f475;&#x1f3ff;</string>
+	<key>shortcut</key><string>:grandma_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f476;</string>
+	<key>shortcut</key><string>:baby:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f476;&#x1f3fb;</string>
+	<key>shortcut</key><string>:baby_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f476;&#x1f3fc;</string>
+	<key>shortcut</key><string>:baby_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f476;&#x1f3fd;</string>
+	<key>shortcut</key><string>:baby_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f476;&#x1f3fe;</string>
+	<key>shortcut</key><string>:baby_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f476;&#x1f3ff;</string>
+	<key>shortcut</key><string>:baby_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f477;</string>
+	<key>shortcut</key><string>:construction_worker:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f477;&#x1f3fb;</string>
+	<key>shortcut</key><string>:construction_worker_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f477;&#x1f3fc;</string>
+	<key>shortcut</key><string>:construction_worker_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f477;&#x1f3fd;</string>
+	<key>shortcut</key><string>:construction_worker_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f477;&#x1f3fe;</string>
+	<key>shortcut</key><string>:construction_worker_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f477;&#x1f3ff;</string>
+	<key>shortcut</key><string>:construction_worker_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f478;</string>
+	<key>shortcut</key><string>:princess:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f478;&#x1f3fb;</string>
+	<key>shortcut</key><string>:princess_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f478;&#x1f3fc;</string>
+	<key>shortcut</key><string>:princess_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f478;&#x1f3fd;</string>
+	<key>shortcut</key><string>:princess_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f478;&#x1f3fe;</string>
+	<key>shortcut</key><string>:princess_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f478;&#x1f3ff;</string>
+	<key>shortcut</key><string>:princess_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f479;</string>
+	<key>shortcut</key><string>:japanese_ogre:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f47a;</string>
+	<key>shortcut</key><string>:japanese_goblin:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f47b;</string>
+	<key>shortcut</key><string>:ghost:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f47c;</string>
+	<key>shortcut</key><string>:angel:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f47c;&#x1f3fb;</string>
+	<key>shortcut</key><string>:angel_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f47c;&#x1f3fc;</string>
+	<key>shortcut</key><string>:angel_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f47c;&#x1f3fd;</string>
+	<key>shortcut</key><string>:angel_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f47c;&#x1f3fe;</string>
+	<key>shortcut</key><string>:angel_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f47c;&#x1f3ff;</string>
+	<key>shortcut</key><string>:angel_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f47d;</string>
+	<key>shortcut</key><string>:alien:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f47e;</string>
+	<key>shortcut</key><string>:space_invader:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f47f;</string>
+	<key>shortcut</key><string>:imp:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f480;</string>
+	<key>shortcut</key><string>:skull:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f480;</string>
+	<key>shortcut</key><string>:skeleton:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f481;</string>
+	<key>shortcut</key><string>:information_desk_person:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f481;&#x1f3fb;</string>
+	<key>shortcut</key><string>:information_desk_person_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f481;&#x1f3fc;</string>
+	<key>shortcut</key><string>:information_desk_person_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f481;&#x1f3fd;</string>
+	<key>shortcut</key><string>:information_desk_person_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f481;&#x1f3fe;</string>
+	<key>shortcut</key><string>:information_desk_person_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f481;&#x1f3ff;</string>
+	<key>shortcut</key><string>:information_desk_person_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f482;</string>
+	<key>shortcut</key><string>:guardsman:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f482;&#x1f3fb;</string>
+	<key>shortcut</key><string>:guardsman_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f482;&#x1f3fc;</string>
+	<key>shortcut</key><string>:guardsman_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f482;&#x1f3fd;</string>
+	<key>shortcut</key><string>:guardsman_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f482;&#x1f3fe;</string>
+	<key>shortcut</key><string>:guardsman_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f482;&#x1f3ff;</string>
+	<key>shortcut</key><string>:guardsman_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f483;</string>
+	<key>shortcut</key><string>:dancer:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f483;&#x1f3fb;</string>
+	<key>shortcut</key><string>:dancer_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f483;&#x1f3fc;</string>
+	<key>shortcut</key><string>:dancer_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f483;&#x1f3fd;</string>
+	<key>shortcut</key><string>:dancer_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f483;&#x1f3fe;</string>
+	<key>shortcut</key><string>:dancer_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f483;&#x1f3ff;</string>
+	<key>shortcut</key><string>:dancer_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f484;</string>
+	<key>shortcut</key><string>:lipstick:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f485;</string>
+	<key>shortcut</key><string>:nail_care:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f485;&#x1f3fb;</string>
+	<key>shortcut</key><string>:nail_care_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f485;&#x1f3fc;</string>
+	<key>shortcut</key><string>:nail_care_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f485;&#x1f3fd;</string>
+	<key>shortcut</key><string>:nail_care_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f485;&#x1f3fe;</string>
+	<key>shortcut</key><string>:nail_care_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f485;&#x1f3ff;</string>
+	<key>shortcut</key><string>:nail_care_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f486;</string>
+	<key>shortcut</key><string>:massage:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f486;&#x1f3fb;</string>
+	<key>shortcut</key><string>:massage_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f486;&#x1f3fc;</string>
+	<key>shortcut</key><string>:massage_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f486;&#x1f3fd;</string>
+	<key>shortcut</key><string>:massage_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f486;&#x1f3fe;</string>
+	<key>shortcut</key><string>:massage_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f486;&#x1f3ff;</string>
+	<key>shortcut</key><string>:massage_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f487;</string>
+	<key>shortcut</key><string>:haircut:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f487;&#x1f3fb;</string>
+	<key>shortcut</key><string>:haircut_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f487;&#x1f3fc;</string>
+	<key>shortcut</key><string>:haircut_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f487;&#x1f3fd;</string>
+	<key>shortcut</key><string>:haircut_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f487;&#x1f3fe;</string>
+	<key>shortcut</key><string>:haircut_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f487;&#x1f3ff;</string>
+	<key>shortcut</key><string>:haircut_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f488;</string>
+	<key>shortcut</key><string>:barber:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f489;</string>
+	<key>shortcut</key><string>:syringe:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f48a;</string>
+	<key>shortcut</key><string>:pill:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f48b;</string>
+	<key>shortcut</key><string>:kiss:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f48c;</string>
+	<key>shortcut</key><string>:love_letter:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f48d;</string>
+	<key>shortcut</key><string>:ring:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f48e;</string>
+	<key>shortcut</key><string>:gem:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f48f;</string>
+	<key>shortcut</key><string>:couplekiss:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f490;</string>
+	<key>shortcut</key><string>:bouquet:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f491;</string>
+	<key>shortcut</key><string>:couple_with_heart:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f492;</string>
+	<key>shortcut</key><string>:wedding:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f493;</string>
+	<key>shortcut</key><string>:heartbeat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f494;</string>
+	<key>shortcut</key><string>:broken_heart:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f495;</string>
+	<key>shortcut</key><string>:two_hearts:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f496;</string>
+	<key>shortcut</key><string>:sparkling_heart:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f497;</string>
+	<key>shortcut</key><string>:heartpulse:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f498;</string>
+	<key>shortcut</key><string>:cupid:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f499;</string>
+	<key>shortcut</key><string>:blue_heart:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f49a;</string>
+	<key>shortcut</key><string>:green_heart:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f49b;</string>
+	<key>shortcut</key><string>:yellow_heart:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f49c;</string>
+	<key>shortcut</key><string>:purple_heart:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f49d;</string>
+	<key>shortcut</key><string>:gift_heart:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f49e;</string>
+	<key>shortcut</key><string>:revolving_hearts:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f49f;</string>
+	<key>shortcut</key><string>:heart_decoration:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4a0;</string>
+	<key>shortcut</key><string>:diamond_shape_with_a_dot_inside:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4a1;</string>
+	<key>shortcut</key><string>:bulb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4a2;</string>
+	<key>shortcut</key><string>:anger:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4a3;</string>
+	<key>shortcut</key><string>:bomb:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4a4;</string>
+	<key>shortcut</key><string>:zzz:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4a5;</string>
+	<key>shortcut</key><string>:boom:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4a6;</string>
+	<key>shortcut</key><string>:sweat_drops:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4a7;</string>
+	<key>shortcut</key><string>:droplet:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4a8;</string>
+	<key>shortcut</key><string>:dash:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4a9;</string>
+	<key>shortcut</key><string>:poop:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4a9;</string>
+	<key>shortcut</key><string>:shit:|:hankey:|:poo:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4aa;</string>
+	<key>shortcut</key><string>:muscle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4aa;&#x1f3fb;</string>
+	<key>shortcut</key><string>:muscle_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4aa;&#x1f3fc;</string>
+	<key>shortcut</key><string>:muscle_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4aa;&#x1f3fd;</string>
+	<key>shortcut</key><string>:muscle_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4aa;&#x1f3fe;</string>
+	<key>shortcut</key><string>:muscle_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4aa;&#x1f3ff;</string>
+	<key>shortcut</key><string>:muscle_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4ab;</string>
+	<key>shortcut</key><string>:dizzy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4ac;</string>
+	<key>shortcut</key><string>:speech_balloon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4ad;</string>
+	<key>shortcut</key><string>:thought_balloon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4ae;</string>
+	<key>shortcut</key><string>:white_flower:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4af;</string>
+	<key>shortcut</key><string>:100:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4b0;</string>
+	<key>shortcut</key><string>:moneybag:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4b1;</string>
+	<key>shortcut</key><string>:currency_exchange:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4b2;</string>
+	<key>shortcut</key><string>:heavy_dollar_sign:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4b3;</string>
+	<key>shortcut</key><string>:credit_card:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4b4;</string>
+	<key>shortcut</key><string>:yen:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4b5;</string>
+	<key>shortcut</key><string>:dollar:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4b6;</string>
+	<key>shortcut</key><string>:euro:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4b7;</string>
+	<key>shortcut</key><string>:pound:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4b8;</string>
+	<key>shortcut</key><string>:money_with_wings:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4b9;</string>
+	<key>shortcut</key><string>:chart:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4ba;</string>
+	<key>shortcut</key><string>:seat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4bb;</string>
+	<key>shortcut</key><string>:computer:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4bc;</string>
+	<key>shortcut</key><string>:briefcase:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4bd;</string>
+	<key>shortcut</key><string>:minidisc:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4be;</string>
+	<key>shortcut</key><string>:floppy_disk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4bf;</string>
+	<key>shortcut</key><string>:cd:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4c0;</string>
+	<key>shortcut</key><string>:dvd:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4c1;</string>
+	<key>shortcut</key><string>:file_folder:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4c2;</string>
+	<key>shortcut</key><string>:open_file_folder:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4c3;</string>
+	<key>shortcut</key><string>:page_with_curl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4c4;</string>
+	<key>shortcut</key><string>:page_facing_up:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4c5;</string>
+	<key>shortcut</key><string>:date:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4c6;</string>
+	<key>shortcut</key><string>:calendar:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4c7;</string>
+	<key>shortcut</key><string>:card_index:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4c8;</string>
+	<key>shortcut</key><string>:chart_with_upwards_trend:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4c9;</string>
+	<key>shortcut</key><string>:chart_with_downwards_trend:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4ca;</string>
+	<key>shortcut</key><string>:bar_chart:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4cb;</string>
+	<key>shortcut</key><string>:clipboard:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4cc;</string>
+	<key>shortcut</key><string>:pushpin:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4cd;</string>
+	<key>shortcut</key><string>:round_pushpin:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4ce;</string>
+	<key>shortcut</key><string>:paperclip:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4cf;</string>
+	<key>shortcut</key><string>:straight_ruler:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4d0;</string>
+	<key>shortcut</key><string>:triangular_ruler:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4d1;</string>
+	<key>shortcut</key><string>:bookmark_tabs:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4d2;</string>
+	<key>shortcut</key><string>:ledger:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4d3;</string>
+	<key>shortcut</key><string>:notebook:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4d4;</string>
+	<key>shortcut</key><string>:notebook_with_decorative_cover:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4d5;</string>
+	<key>shortcut</key><string>:closed_book:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4d6;</string>
+	<key>shortcut</key><string>:book:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4d7;</string>
+	<key>shortcut</key><string>:green_book:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4d8;</string>
+	<key>shortcut</key><string>:blue_book:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4d9;</string>
+	<key>shortcut</key><string>:orange_book:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4da;</string>
+	<key>shortcut</key><string>:books:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4db;</string>
+	<key>shortcut</key><string>:name_badge:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4dc;</string>
+	<key>shortcut</key><string>:scroll:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4dd;</string>
+	<key>shortcut</key><string>:pencil:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4de;</string>
+	<key>shortcut</key><string>:telephone_receiver:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4df;</string>
+	<key>shortcut</key><string>:pager:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4e0;</string>
+	<key>shortcut</key><string>:fax:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4e1;</string>
+	<key>shortcut</key><string>:satellite:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4e2;</string>
+	<key>shortcut</key><string>:loudspeaker:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4e3;</string>
+	<key>shortcut</key><string>:mega:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4e4;</string>
+	<key>shortcut</key><string>:outbox_tray:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4e5;</string>
+	<key>shortcut</key><string>:inbox_tray:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4e6;</string>
+	<key>shortcut</key><string>:package:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4e7;</string>
+	<key>shortcut</key><string>:e-mail:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4e7;</string>
+	<key>shortcut</key><string>:email:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4e8;</string>
+	<key>shortcut</key><string>:incoming_envelope:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4e9;</string>
+	<key>shortcut</key><string>:envelope_with_arrow:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4ea;</string>
+	<key>shortcut</key><string>:mailbox_closed:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4eb;</string>
+	<key>shortcut</key><string>:mailbox:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4ec;</string>
+	<key>shortcut</key><string>:mailbox_with_mail:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4ed;</string>
+	<key>shortcut</key><string>:mailbox_with_no_mail:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4ee;</string>
+	<key>shortcut</key><string>:postbox:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4ef;</string>
+	<key>shortcut</key><string>:postal_horn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4f0;</string>
+	<key>shortcut</key><string>:newspaper:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4f1;</string>
+	<key>shortcut</key><string>:iphone:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4f2;</string>
+	<key>shortcut</key><string>:calling:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4f3;</string>
+	<key>shortcut</key><string>:vibration_mode:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4f4;</string>
+	<key>shortcut</key><string>:mobile_phone_off:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4f5;</string>
+	<key>shortcut</key><string>:no_mobile_phones:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4f6;</string>
+	<key>shortcut</key><string>:signal_strength:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4f7;</string>
+	<key>shortcut</key><string>:camera:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4f8;</string>
+	<key>shortcut</key><string>:camera_with_flash:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4f9;</string>
+	<key>shortcut</key><string>:video_camera:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4fa;</string>
+	<key>shortcut</key><string>:tv:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4fb;</string>
+	<key>shortcut</key><string>:radio:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4fc;</string>
+	<key>shortcut</key><string>:vhs:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4fd;</string>
+	<key>shortcut</key><string>:projector:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4fd;</string>
+	<key>shortcut</key><string>:film_projector:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f4ff;</string>
+	<key>shortcut</key><string>:prayer_beads:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f500;</string>
+	<key>shortcut</key><string>:twisted_rightwards_arrows:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f501;</string>
+	<key>shortcut</key><string>:repeat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f502;</string>
+	<key>shortcut</key><string>:repeat_one:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f503;</string>
+	<key>shortcut</key><string>:arrows_clockwise:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f504;</string>
+	<key>shortcut</key><string>:arrows_counterclockwise:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f505;</string>
+	<key>shortcut</key><string>:low_brightness:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f506;</string>
+	<key>shortcut</key><string>:high_brightness:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f507;</string>
+	<key>shortcut</key><string>:mute:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f508;</string>
+	<key>shortcut</key><string>:speaker:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f509;</string>
+	<key>shortcut</key><string>:sound:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f50a;</string>
+	<key>shortcut</key><string>:loud_sound:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f50b;</string>
+	<key>shortcut</key><string>:battery:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f50c;</string>
+	<key>shortcut</key><string>:electric_plug:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f50d;</string>
+	<key>shortcut</key><string>:mag:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f50e;</string>
+	<key>shortcut</key><string>:mag_right:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f50f;</string>
+	<key>shortcut</key><string>:lock_with_ink_pen:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f510;</string>
+	<key>shortcut</key><string>:closed_lock_with_key:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f511;</string>
+	<key>shortcut</key><string>:key:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f512;</string>
+	<key>shortcut</key><string>:lock:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f513;</string>
+	<key>shortcut</key><string>:unlock:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f514;</string>
+	<key>shortcut</key><string>:bell:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f515;</string>
+	<key>shortcut</key><string>:no_bell:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f516;</string>
+	<key>shortcut</key><string>:bookmark:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f517;</string>
+	<key>shortcut</key><string>:link:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f518;</string>
+	<key>shortcut</key><string>:radio_button:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f519;</string>
+	<key>shortcut</key><string>:back:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f51a;</string>
+	<key>shortcut</key><string>:end:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f51b;</string>
+	<key>shortcut</key><string>:on:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f51c;</string>
+	<key>shortcut</key><string>:soon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f51d;</string>
+	<key>shortcut</key><string>:top:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f51e;</string>
+	<key>shortcut</key><string>:underage:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f51f;</string>
+	<key>shortcut</key><string>:keycap_ten:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f520;</string>
+	<key>shortcut</key><string>:capital_abcd:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f521;</string>
+	<key>shortcut</key><string>:abcd:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f522;</string>
+	<key>shortcut</key><string>:1234:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f523;</string>
+	<key>shortcut</key><string>:symbols:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f524;</string>
+	<key>shortcut</key><string>:abc:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f525;</string>
+	<key>shortcut</key><string>:fire:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f525;</string>
+	<key>shortcut</key><string>:flame:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f526;</string>
+	<key>shortcut</key><string>:flashlight:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f527;</string>
+	<key>shortcut</key><string>:wrench:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f528;</string>
+	<key>shortcut</key><string>:hammer:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f529;</string>
+	<key>shortcut</key><string>:nut_and_bolt:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f52a;</string>
+	<key>shortcut</key><string>:knife:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f52b;</string>
+	<key>shortcut</key><string>:gun:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f52c;</string>
+	<key>shortcut</key><string>:microscope:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f52d;</string>
+	<key>shortcut</key><string>:telescope:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f52e;</string>
+	<key>shortcut</key><string>:crystal_ball:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f52f;</string>
+	<key>shortcut</key><string>:six_pointed_star:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f530;</string>
+	<key>shortcut</key><string>:beginner:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f531;</string>
+	<key>shortcut</key><string>:trident:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f532;</string>
+	<key>shortcut</key><string>:black_square_button:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f533;</string>
+	<key>shortcut</key><string>:white_square_button:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f534;</string>
+	<key>shortcut</key><string>:red_circle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f535;</string>
+	<key>shortcut</key><string>:large_blue_circle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f536;</string>
+	<key>shortcut</key><string>:large_orange_diamond:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f537;</string>
+	<key>shortcut</key><string>:large_blue_diamond:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f538;</string>
+	<key>shortcut</key><string>:small_orange_diamond:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f539;</string>
+	<key>shortcut</key><string>:small_blue_diamond:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f53a;</string>
+	<key>shortcut</key><string>:small_red_triangle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f53b;</string>
+	<key>shortcut</key><string>:small_red_triangle_down:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f53c;</string>
+	<key>shortcut</key><string>:arrow_up_small:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f53d;</string>
+	<key>shortcut</key><string>:arrow_down_small:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f549;</string>
+	<key>shortcut</key><string>:om_symbol:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f54a;</string>
+	<key>shortcut</key><string>:dove:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f54a;</string>
+	<key>shortcut</key><string>:dove_of_peace:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f54b;</string>
+	<key>shortcut</key><string>:kaaba:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f54c;</string>
+	<key>shortcut</key><string>:mosque:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f54d;</string>
+	<key>shortcut</key><string>:synagogue:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f54e;</string>
+	<key>shortcut</key><string>:menorah:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f550;</string>
+	<key>shortcut</key><string>:clock1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f551;</string>
+	<key>shortcut</key><string>:clock2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f552;</string>
+	<key>shortcut</key><string>:clock3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f553;</string>
+	<key>shortcut</key><string>:clock4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f554;</string>
+	<key>shortcut</key><string>:clock5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f555;</string>
+	<key>shortcut</key><string>:clock6:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f556;</string>
+	<key>shortcut</key><string>:clock7:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f557;</string>
+	<key>shortcut</key><string>:clock8:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f558;</string>
+	<key>shortcut</key><string>:clock9:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f559;</string>
+	<key>shortcut</key><string>:clock10:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f55a;</string>
+	<key>shortcut</key><string>:clock11:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f55b;</string>
+	<key>shortcut</key><string>:clock12:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f55c;</string>
+	<key>shortcut</key><string>:clock130:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f55d;</string>
+	<key>shortcut</key><string>:clock230:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f55e;</string>
+	<key>shortcut</key><string>:clock330:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f55f;</string>
+	<key>shortcut</key><string>:clock430:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f560;</string>
+	<key>shortcut</key><string>:clock530:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f561;</string>
+	<key>shortcut</key><string>:clock630:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f562;</string>
+	<key>shortcut</key><string>:clock730:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f563;</string>
+	<key>shortcut</key><string>:clock830:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f564;</string>
+	<key>shortcut</key><string>:clock930:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f565;</string>
+	<key>shortcut</key><string>:clock1030:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f566;</string>
+	<key>shortcut</key><string>:clock1130:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f567;</string>
+	<key>shortcut</key><string>:clock1230:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f56f;</string>
+	<key>shortcut</key><string>:candle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f570;</string>
+	<key>shortcut</key><string>:clock:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f570;</string>
+	<key>shortcut</key><string>:mantlepiece_clock:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f573;</string>
+	<key>shortcut</key><string>:hole:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f574;</string>
+	<key>shortcut</key><string>:levitate:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f574;</string>
+	<key>shortcut</key><string>:man_in_business_suit_levitating:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f575;</string>
+	<key>shortcut</key><string>:spy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f575;</string>
+	<key>shortcut</key><string>:sleuth_or_spy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f575;&#x1f3fb;</string>
+	<key>shortcut</key><string>:spy_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f575;&#x1f3fb;</string>
+	<key>shortcut</key><string>:sleuth_or_spy_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f575;&#x1f3fc;</string>
+	<key>shortcut</key><string>:spy_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f575;&#x1f3fc;</string>
+	<key>shortcut</key><string>:sleuth_or_spy_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f575;&#x1f3fd;</string>
+	<key>shortcut</key><string>:spy_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f575;&#x1f3fd;</string>
+	<key>shortcut</key><string>:sleuth_or_spy_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f575;&#x1f3fe;</string>
+	<key>shortcut</key><string>:spy_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f575;&#x1f3fe;</string>
+	<key>shortcut</key><string>:sleuth_or_spy_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f575;&#x1f3ff;</string>
+	<key>shortcut</key><string>:spy_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f575;&#x1f3ff;</string>
+	<key>shortcut</key><string>:sleuth_or_spy_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f576;</string>
+	<key>shortcut</key><string>:dark_sunglasses:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f577;</string>
+	<key>shortcut</key><string>:spider:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f578;</string>
+	<key>shortcut</key><string>:spider_web:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f579;</string>
+	<key>shortcut</key><string>:joystick:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f57a;</string>
+	<key>shortcut</key><string>:man_dancing:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f57a;</string>
+	<key>shortcut</key><string>:male_dancer:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f57a;&#x1f3fb;</string>
+	<key>shortcut</key><string>:man_dancing_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f57a;&#x1f3fb;</string>
+	<key>shortcut</key><string>:male_dancer_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f57a;&#x1f3fc;</string>
+	<key>shortcut</key><string>:man_dancing_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f57a;&#x1f3fc;</string>
+	<key>shortcut</key><string>:male_dancer_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f57a;&#x1f3fd;</string>
+	<key>shortcut</key><string>:man_dancing_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f57a;&#x1f3fd;</string>
+	<key>shortcut</key><string>:male_dancer_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f57a;&#x1f3fe;</string>
+	<key>shortcut</key><string>:man_dancing_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f57a;&#x1f3fe;</string>
+	<key>shortcut</key><string>:male_dancer_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f57a;&#x1f3ff;</string>
+	<key>shortcut</key><string>:man_dancing_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f57a;&#x1f3ff;</string>
+	<key>shortcut</key><string>:male_dancer_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f587;</string>
+	<key>shortcut</key><string>:paperclips:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f587;</string>
+	<key>shortcut</key><string>:linked_paperclips:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f58a;</string>
+	<key>shortcut</key><string>:pen_ballpoint:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f58a;</string>
+	<key>shortcut</key><string>:lower_left_ballpoint_pen:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f58b;</string>
+	<key>shortcut</key><string>:pen_fountain:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f58b;</string>
+	<key>shortcut</key><string>:lower_left_fountain_pen:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f58c;</string>
+	<key>shortcut</key><string>:paintbrush:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f58c;</string>
+	<key>shortcut</key><string>:lower_left_paintbrush:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f58d;</string>
+	<key>shortcut</key><string>:crayon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f58d;</string>
+	<key>shortcut</key><string>:lower_left_crayon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f590;</string>
+	<key>shortcut</key><string>:hand_splayed:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f590;</string>
+	<key>shortcut</key><string>:raised_hand_with_fingers_splayed:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f590;&#x1f3fb;</string>
+	<key>shortcut</key><string>:hand_splayed_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f590;&#x1f3fb;</string>
+	<key>shortcut</key><string>:raised_hand_with_fingers_splayed_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f590;&#x1f3fc;</string>
+	<key>shortcut</key><string>:hand_splayed_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f590;&#x1f3fc;</string>
+	<key>shortcut</key><string>:raised_hand_with_fingers_splayed_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f590;&#x1f3fd;</string>
+	<key>shortcut</key><string>:hand_splayed_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f590;&#x1f3fd;</string>
+	<key>shortcut</key><string>:raised_hand_with_fingers_splayed_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f590;&#x1f3fe;</string>
+	<key>shortcut</key><string>:hand_splayed_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f590;&#x1f3fe;</string>
+	<key>shortcut</key><string>:raised_hand_with_fingers_splayed_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f590;&#x1f3ff;</string>
+	<key>shortcut</key><string>:hand_splayed_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f590;&#x1f3ff;</string>
+	<key>shortcut</key><string>:raised_hand_with_fingers_splayed_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f595;</string>
+	<key>shortcut</key><string>:middle_finger:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f595;</string>
+	<key>shortcut</key><string>:reversed_hand_with_middle_finger_extended:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f595;&#x1f3fb;</string>
+	<key>shortcut</key><string>:middle_finger_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f595;&#x1f3fb;</string>
+	<key>shortcut</key><string>:reversed_hand_with_middle_finger_extended_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f595;&#x1f3fc;</string>
+	<key>shortcut</key><string>:middle_finger_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f595;&#x1f3fc;</string>
+	<key>shortcut</key><string>:reversed_hand_with_middle_finger_extended_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f595;&#x1f3fd;</string>
+	<key>shortcut</key><string>:middle_finger_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f595;&#x1f3fd;</string>
+	<key>shortcut</key><string>:reversed_hand_with_middle_finger_extended_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f595;&#x1f3fe;</string>
+	<key>shortcut</key><string>:middle_finger_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f595;&#x1f3fe;</string>
+	<key>shortcut</key><string>:reversed_hand_with_middle_finger_extended_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f595;&#x1f3ff;</string>
+	<key>shortcut</key><string>:middle_finger_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f595;&#x1f3ff;</string>
+	<key>shortcut</key><string>:reversed_hand_with_middle_finger_extended_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f596;</string>
+	<key>shortcut</key><string>:vulcan:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f596;</string>
+	<key>shortcut</key><string>:raised_hand_with_part_between_middle_and_ring_fingers:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f596;&#x1f3fb;</string>
+	<key>shortcut</key><string>:vulcan_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f596;&#x1f3fb;</string>
+	<key>shortcut</key><string>:raised_hand_with_part_between_middle_and_ring_fingers_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f596;&#x1f3fc;</string>
+	<key>shortcut</key><string>:vulcan_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f596;&#x1f3fc;</string>
+	<key>shortcut</key><string>:raised_hand_with_part_between_middle_and_ring_fingers_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f596;&#x1f3fd;</string>
+	<key>shortcut</key><string>:vulcan_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f596;&#x1f3fd;</string>
+	<key>shortcut</key><string>:raised_hand_with_part_between_middle_and_ring_fingers_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f596;&#x1f3fe;</string>
+	<key>shortcut</key><string>:vulcan_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f596;&#x1f3fe;</string>
+	<key>shortcut</key><string>:raised_hand_with_part_between_middle_and_ring_fingers_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f596;&#x1f3ff;</string>
+	<key>shortcut</key><string>:vulcan_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f596;&#x1f3ff;</string>
+	<key>shortcut</key><string>:raised_hand_with_part_between_middle_and_ring_fingers_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5a4;</string>
+	<key>shortcut</key><string>:black_heart:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5a5;</string>
+	<key>shortcut</key><string>:desktop:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5a5;</string>
+	<key>shortcut</key><string>:desktop_computer:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5a8;</string>
+	<key>shortcut</key><string>:printer:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5b1;</string>
+	<key>shortcut</key><string>:mouse_three_button:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5b1;</string>
+	<key>shortcut</key><string>:three_button_mouse:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5b2;</string>
+	<key>shortcut</key><string>:trackball:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5bc;</string>
+	<key>shortcut</key><string>:frame_photo:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5bc;</string>
+	<key>shortcut</key><string>:frame_with_picture:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5c2;</string>
+	<key>shortcut</key><string>:dividers:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5c2;</string>
+	<key>shortcut</key><string>:card_index_dividers:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5c3;</string>
+	<key>shortcut</key><string>:card_box:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5c3;</string>
+	<key>shortcut</key><string>:card_file_box:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5c4;</string>
+	<key>shortcut</key><string>:file_cabinet:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5d1;</string>
+	<key>shortcut</key><string>:wastebasket:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5d2;</string>
+	<key>shortcut</key><string>:notepad_spiral:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5d2;</string>
+	<key>shortcut</key><string>:spiral_note_pad:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5d3;</string>
+	<key>shortcut</key><string>:calendar_spiral:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5d3;</string>
+	<key>shortcut</key><string>:spiral_calendar_pad:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5dc;</string>
+	<key>shortcut</key><string>:compression:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5dd;</string>
+	<key>shortcut</key><string>:key2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5dd;</string>
+	<key>shortcut</key><string>:old_key:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5de;</string>
+	<key>shortcut</key><string>:newspaper2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5de;</string>
+	<key>shortcut</key><string>:rolled_up_newspaper:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5e1;</string>
+	<key>shortcut</key><string>:dagger:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5e1;</string>
+	<key>shortcut</key><string>:dagger_knife:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5e3;</string>
+	<key>shortcut</key><string>:speaking_head:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5e3;</string>
+	<key>shortcut</key><string>:speaking_head_in_silhouette:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5e8;</string>
+	<key>shortcut</key><string>:speech_left:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5e8;</string>
+	<key>shortcut</key><string>:left_speech_bubble:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5ef;</string>
+	<key>shortcut</key><string>:anger_right:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5ef;</string>
+	<key>shortcut</key><string>:right_anger_bubble:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5f3;</string>
+	<key>shortcut</key><string>:ballot_box:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5f3;</string>
+	<key>shortcut</key><string>:ballot_box_with_ballot:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5fa;</string>
+	<key>shortcut</key><string>:map:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5fa;</string>
+	<key>shortcut</key><string>:world_map:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5fb;</string>
+	<key>shortcut</key><string>:mount_fuji:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5fc;</string>
+	<key>shortcut</key><string>:tokyo_tower:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5fd;</string>
+	<key>shortcut</key><string>:statue_of_liberty:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5fe;</string>
+	<key>shortcut</key><string>:japan:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f5ff;</string>
+	<key>shortcut</key><string>:moyai:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f600;</string>
+	<key>shortcut</key><string>:grinning:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f601;</string>
+	<key>shortcut</key><string>:grin:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f602;</string>
+	<key>shortcut</key><string>:joy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f603;</string>
+	<key>shortcut</key><string>:smiley:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f604;</string>
+	<key>shortcut</key><string>:smile:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f605;</string>
+	<key>shortcut</key><string>:sweat_smile:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f606;</string>
+	<key>shortcut</key><string>:laughing:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f606;</string>
+	<key>shortcut</key><string>:satisfied:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f607;</string>
+	<key>shortcut</key><string>:innocent:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f608;</string>
+	<key>shortcut</key><string>:smiling_imp:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f609;</string>
+	<key>shortcut</key><string>:wink:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f60a;</string>
+	<key>shortcut</key><string>:blush:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f60b;</string>
+	<key>shortcut</key><string>:yum:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f60c;</string>
+	<key>shortcut</key><string>:relieved:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f60d;</string>
+	<key>shortcut</key><string>:heart_eyes:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f60e;</string>
+	<key>shortcut</key><string>:sunglasses:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f60f;</string>
+	<key>shortcut</key><string>:smirk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f610;</string>
+	<key>shortcut</key><string>:neutral_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f611;</string>
+	<key>shortcut</key><string>:expressionless:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f612;</string>
+	<key>shortcut</key><string>:unamused:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f613;</string>
+	<key>shortcut</key><string>:sweat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f614;</string>
+	<key>shortcut</key><string>:pensive:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f615;</string>
+	<key>shortcut</key><string>:confused:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f616;</string>
+	<key>shortcut</key><string>:confounded:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f617;</string>
+	<key>shortcut</key><string>:kissing:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f618;</string>
+	<key>shortcut</key><string>:kissing_heart:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f619;</string>
+	<key>shortcut</key><string>:kissing_smiling_eyes:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f61a;</string>
+	<key>shortcut</key><string>:kissing_closed_eyes:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f61b;</string>
+	<key>shortcut</key><string>:stuck_out_tongue:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f61c;</string>
+	<key>shortcut</key><string>:stuck_out_tongue_winking_eye:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f61d;</string>
+	<key>shortcut</key><string>:stuck_out_tongue_closed_eyes:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f61e;</string>
+	<key>shortcut</key><string>:disappointed:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f61f;</string>
+	<key>shortcut</key><string>:worried:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f620;</string>
+	<key>shortcut</key><string>:angry:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f621;</string>
+	<key>shortcut</key><string>:rage:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f622;</string>
+	<key>shortcut</key><string>:cry:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f623;</string>
+	<key>shortcut</key><string>:persevere:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f624;</string>
+	<key>shortcut</key><string>:triumph:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f625;</string>
+	<key>shortcut</key><string>:disappointed_relieved:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f626;</string>
+	<key>shortcut</key><string>:frowning:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f627;</string>
+	<key>shortcut</key><string>:anguished:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f628;</string>
+	<key>shortcut</key><string>:fearful:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f629;</string>
+	<key>shortcut</key><string>:weary:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f62a;</string>
+	<key>shortcut</key><string>:sleepy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f62b;</string>
+	<key>shortcut</key><string>:tired_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f62c;</string>
+	<key>shortcut</key><string>:grimacing:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f62d;</string>
+	<key>shortcut</key><string>:sob:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f62e;</string>
+	<key>shortcut</key><string>:open_mouth:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f62f;</string>
+	<key>shortcut</key><string>:hushed:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f630;</string>
+	<key>shortcut</key><string>:cold_sweat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f631;</string>
+	<key>shortcut</key><string>:scream:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f632;</string>
+	<key>shortcut</key><string>:astonished:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f633;</string>
+	<key>shortcut</key><string>:flushed:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f634;</string>
+	<key>shortcut</key><string>:sleeping:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f635;</string>
+	<key>shortcut</key><string>:dizzy_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f636;</string>
+	<key>shortcut</key><string>:no_mouth:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f637;</string>
+	<key>shortcut</key><string>:mask:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f638;</string>
+	<key>shortcut</key><string>:smile_cat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f639;</string>
+	<key>shortcut</key><string>:joy_cat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f63a;</string>
+	<key>shortcut</key><string>:smiley_cat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f63b;</string>
+	<key>shortcut</key><string>:heart_eyes_cat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f63c;</string>
+	<key>shortcut</key><string>:smirk_cat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f63d;</string>
+	<key>shortcut</key><string>:kissing_cat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f63e;</string>
+	<key>shortcut</key><string>:pouting_cat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f63f;</string>
+	<key>shortcut</key><string>:crying_cat_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f640;</string>
+	<key>shortcut</key><string>:scream_cat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f641;</string>
+	<key>shortcut</key><string>:slight_frown:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f641;</string>
+	<key>shortcut</key><string>:slightly_frowning_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f642;</string>
+	<key>shortcut</key><string>:slight_smile:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f642;</string>
+	<key>shortcut</key><string>:slightly_smiling_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f643;</string>
+	<key>shortcut</key><string>:upside_down:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f643;</string>
+	<key>shortcut</key><string>:upside_down_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f644;</string>
+	<key>shortcut</key><string>:rolling_eyes:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f644;</string>
+	<key>shortcut</key><string>:face_with_rolling_eyes:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f645;</string>
+	<key>shortcut</key><string>:no_good:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f645;&#x1f3fb;</string>
+	<key>shortcut</key><string>:no_good_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f645;&#x1f3fc;</string>
+	<key>shortcut</key><string>:no_good_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f645;&#x1f3fd;</string>
+	<key>shortcut</key><string>:no_good_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f645;&#x1f3fe;</string>
+	<key>shortcut</key><string>:no_good_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f645;&#x1f3ff;</string>
+	<key>shortcut</key><string>:no_good_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f646;</string>
+	<key>shortcut</key><string>:ok_woman:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f646;&#x1f3fb;</string>
+	<key>shortcut</key><string>:ok_woman_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f646;&#x1f3fc;</string>
+	<key>shortcut</key><string>:ok_woman_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f646;&#x1f3fd;</string>
+	<key>shortcut</key><string>:ok_woman_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f646;&#x1f3fe;</string>
+	<key>shortcut</key><string>:ok_woman_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f646;&#x1f3ff;</string>
+	<key>shortcut</key><string>:ok_woman_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f647;</string>
+	<key>shortcut</key><string>:bow:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f647;&#x1f3fb;</string>
+	<key>shortcut</key><string>:bow_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f647;&#x1f3fc;</string>
+	<key>shortcut</key><string>:bow_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f647;&#x1f3fd;</string>
+	<key>shortcut</key><string>:bow_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f647;&#x1f3fe;</string>
+	<key>shortcut</key><string>:bow_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f647;&#x1f3ff;</string>
+	<key>shortcut</key><string>:bow_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f648;</string>
+	<key>shortcut</key><string>:see_no_evil:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f649;</string>
+	<key>shortcut</key><string>:hear_no_evil:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64a;</string>
+	<key>shortcut</key><string>:speak_no_evil:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64b;</string>
+	<key>shortcut</key><string>:raising_hand:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64b;&#x1f3fb;</string>
+	<key>shortcut</key><string>:raising_hand_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64b;&#x1f3fc;</string>
+	<key>shortcut</key><string>:raising_hand_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64b;&#x1f3fd;</string>
+	<key>shortcut</key><string>:raising_hand_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64b;&#x1f3fe;</string>
+	<key>shortcut</key><string>:raising_hand_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64b;&#x1f3ff;</string>
+	<key>shortcut</key><string>:raising_hand_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64c;</string>
+	<key>shortcut</key><string>:raised_hands:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64c;&#x1f3fb;</string>
+	<key>shortcut</key><string>:raised_hands_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64c;&#x1f3fc;</string>
+	<key>shortcut</key><string>:raised_hands_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64c;&#x1f3fd;</string>
+	<key>shortcut</key><string>:raised_hands_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64c;&#x1f3fe;</string>
+	<key>shortcut</key><string>:raised_hands_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64c;&#x1f3ff;</string>
+	<key>shortcut</key><string>:raised_hands_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64d;</string>
+	<key>shortcut</key><string>:person_frowning:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64d;&#x1f3fb;</string>
+	<key>shortcut</key><string>:person_frowning_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64d;&#x1f3fc;</string>
+	<key>shortcut</key><string>:person_frowning_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64d;&#x1f3fd;</string>
+	<key>shortcut</key><string>:person_frowning_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64d;&#x1f3fe;</string>
+	<key>shortcut</key><string>:person_frowning_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64d;&#x1f3ff;</string>
+	<key>shortcut</key><string>:person_frowning_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64e;</string>
+	<key>shortcut</key><string>:person_with_pouting_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64e;&#x1f3fb;</string>
+	<key>shortcut</key><string>:person_with_pouting_face_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64e;&#x1f3fc;</string>
+	<key>shortcut</key><string>:person_with_pouting_face_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64e;&#x1f3fd;</string>
+	<key>shortcut</key><string>:person_with_pouting_face_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64e;&#x1f3fe;</string>
+	<key>shortcut</key><string>:person_with_pouting_face_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64e;&#x1f3ff;</string>
+	<key>shortcut</key><string>:person_with_pouting_face_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64f;</string>
+	<key>shortcut</key><string>:pray:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64f;&#x1f3fb;</string>
+	<key>shortcut</key><string>:pray_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64f;&#x1f3fc;</string>
+	<key>shortcut</key><string>:pray_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64f;&#x1f3fd;</string>
+	<key>shortcut</key><string>:pray_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64f;&#x1f3fe;</string>
+	<key>shortcut</key><string>:pray_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f64f;&#x1f3ff;</string>
+	<key>shortcut</key><string>:pray_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f680;</string>
+	<key>shortcut</key><string>:rocket:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f681;</string>
+	<key>shortcut</key><string>:helicopter:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f682;</string>
+	<key>shortcut</key><string>:steam_locomotive:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f683;</string>
+	<key>shortcut</key><string>:railway_car:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f684;</string>
+	<key>shortcut</key><string>:bullettrain_side:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f685;</string>
+	<key>shortcut</key><string>:bullettrain_front:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f686;</string>
+	<key>shortcut</key><string>:train2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f687;</string>
+	<key>shortcut</key><string>:metro:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f688;</string>
+	<key>shortcut</key><string>:light_rail:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f689;</string>
+	<key>shortcut</key><string>:station:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f68a;</string>
+	<key>shortcut</key><string>:tram:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f68b;</string>
+	<key>shortcut</key><string>:train:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f68c;</string>
+	<key>shortcut</key><string>:bus:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f68d;</string>
+	<key>shortcut</key><string>:oncoming_bus:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f68e;</string>
+	<key>shortcut</key><string>:trolleybus:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f68f;</string>
+	<key>shortcut</key><string>:busstop:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f690;</string>
+	<key>shortcut</key><string>:minibus:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f691;</string>
+	<key>shortcut</key><string>:ambulance:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f692;</string>
+	<key>shortcut</key><string>:fire_engine:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f693;</string>
+	<key>shortcut</key><string>:police_car:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f694;</string>
+	<key>shortcut</key><string>:oncoming_police_car:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f695;</string>
+	<key>shortcut</key><string>:taxi:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f696;</string>
+	<key>shortcut</key><string>:oncoming_taxi:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f697;</string>
+	<key>shortcut</key><string>:red_car:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f698;</string>
+	<key>shortcut</key><string>:oncoming_automobile:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f699;</string>
+	<key>shortcut</key><string>:blue_car:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f69a;</string>
+	<key>shortcut</key><string>:truck:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f69b;</string>
+	<key>shortcut</key><string>:articulated_lorry:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f69c;</string>
+	<key>shortcut</key><string>:tractor:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f69d;</string>
+	<key>shortcut</key><string>:monorail:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f69e;</string>
+	<key>shortcut</key><string>:mountain_railway:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f69f;</string>
+	<key>shortcut</key><string>:suspension_railway:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6a0;</string>
+	<key>shortcut</key><string>:mountain_cableway:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6a1;</string>
+	<key>shortcut</key><string>:aerial_tramway:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6a2;</string>
+	<key>shortcut</key><string>:ship:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6a3;</string>
+	<key>shortcut</key><string>:rowboat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6a3;&#x1f3fb;</string>
+	<key>shortcut</key><string>:rowboat_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6a3;&#x1f3fc;</string>
+	<key>shortcut</key><string>:rowboat_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6a3;&#x1f3fd;</string>
+	<key>shortcut</key><string>:rowboat_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6a3;&#x1f3fe;</string>
+	<key>shortcut</key><string>:rowboat_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6a3;&#x1f3ff;</string>
+	<key>shortcut</key><string>:rowboat_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6a4;</string>
+	<key>shortcut</key><string>:speedboat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6a5;</string>
+	<key>shortcut</key><string>:traffic_light:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6a6;</string>
+	<key>shortcut</key><string>:vertical_traffic_light:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6a7;</string>
+	<key>shortcut</key><string>:construction:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6a8;</string>
+	<key>shortcut</key><string>:rotating_light:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6a9;</string>
+	<key>shortcut</key><string>:triangular_flag_on_post:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6aa;</string>
+	<key>shortcut</key><string>:door:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6ab;</string>
+	<key>shortcut</key><string>:no_entry_sign:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6ac;</string>
+	<key>shortcut</key><string>:smoking:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6ad;</string>
+	<key>shortcut</key><string>:no_smoking:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6ae;</string>
+	<key>shortcut</key><string>:put_litter_in_its_place:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6af;</string>
+	<key>shortcut</key><string>:do_not_litter:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b0;</string>
+	<key>shortcut</key><string>:potable_water:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b1;</string>
+	<key>shortcut</key><string>:non-potable_water:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b2;</string>
+	<key>shortcut</key><string>:bike:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b3;</string>
+	<key>shortcut</key><string>:no_bicycles:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b4;</string>
+	<key>shortcut</key><string>:bicyclist:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b4;&#x1f3fb;</string>
+	<key>shortcut</key><string>:bicyclist_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b4;&#x1f3fc;</string>
+	<key>shortcut</key><string>:bicyclist_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b4;&#x1f3fd;</string>
+	<key>shortcut</key><string>:bicyclist_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b4;&#x1f3fe;</string>
+	<key>shortcut</key><string>:bicyclist_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b4;&#x1f3ff;</string>
+	<key>shortcut</key><string>:bicyclist_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b5;</string>
+	<key>shortcut</key><string>:mountain_bicyclist:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b5;&#x1f3fb;</string>
+	<key>shortcut</key><string>:mountain_bicyclist_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b5;&#x1f3fc;</string>
+	<key>shortcut</key><string>:mountain_bicyclist_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b5;&#x1f3fd;</string>
+	<key>shortcut</key><string>:mountain_bicyclist_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b5;&#x1f3fe;</string>
+	<key>shortcut</key><string>:mountain_bicyclist_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b5;&#x1f3ff;</string>
+	<key>shortcut</key><string>:mountain_bicyclist_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b6;</string>
+	<key>shortcut</key><string>:walking:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b6;&#x1f3fb;</string>
+	<key>shortcut</key><string>:walking_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b6;&#x1f3fc;</string>
+	<key>shortcut</key><string>:walking_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b6;&#x1f3fd;</string>
+	<key>shortcut</key><string>:walking_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b6;&#x1f3fe;</string>
+	<key>shortcut</key><string>:walking_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b6;&#x1f3ff;</string>
+	<key>shortcut</key><string>:walking_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b7;</string>
+	<key>shortcut</key><string>:no_pedestrians:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b8;</string>
+	<key>shortcut</key><string>:children_crossing:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6b9;</string>
+	<key>shortcut</key><string>:mens:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6ba;</string>
+	<key>shortcut</key><string>:womens:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6bb;</string>
+	<key>shortcut</key><string>:restroom:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6bc;</string>
+	<key>shortcut</key><string>:baby_symbol:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6bd;</string>
+	<key>shortcut</key><string>:toilet:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6be;</string>
+	<key>shortcut</key><string>:wc:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6bf;</string>
+	<key>shortcut</key><string>:shower:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6c0;</string>
+	<key>shortcut</key><string>:bath:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6c0;&#x1f3fb;</string>
+	<key>shortcut</key><string>:bath_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6c0;&#x1f3fc;</string>
+	<key>shortcut</key><string>:bath_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6c0;&#x1f3fd;</string>
+	<key>shortcut</key><string>:bath_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6c0;&#x1f3fe;</string>
+	<key>shortcut</key><string>:bath_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6c0;&#x1f3ff;</string>
+	<key>shortcut</key><string>:bath_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6c1;</string>
+	<key>shortcut</key><string>:bathtub:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6c2;</string>
+	<key>shortcut</key><string>:passport_control:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6c3;</string>
+	<key>shortcut</key><string>:customs:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6c4;</string>
+	<key>shortcut</key><string>:baggage_claim:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6c5;</string>
+	<key>shortcut</key><string>:left_luggage:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6cb;</string>
+	<key>shortcut</key><string>:couch:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6cb;</string>
+	<key>shortcut</key><string>:couch_and_lamp:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6cc;</string>
+	<key>shortcut</key><string>:sleeping_accommodation:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6cd;</string>
+	<key>shortcut</key><string>:shopping_bags:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6ce;</string>
+	<key>shortcut</key><string>:bellhop:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6ce;</string>
+	<key>shortcut</key><string>:bellhop_bell:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6cf;</string>
+	<key>shortcut</key><string>:bed:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6d0;</string>
+	<key>shortcut</key><string>:place_of_worship:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6d0;</string>
+	<key>shortcut</key><string>:worship_symbol:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6d1;</string>
+	<key>shortcut</key><string>:octagonal_sign:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6d1;</string>
+	<key>shortcut</key><string>:stop_sign:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6d2;</string>
+	<key>shortcut</key><string>:shopping_cart:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6d2;</string>
+	<key>shortcut</key><string>:shopping_trolley:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6e0;</string>
+	<key>shortcut</key><string>:tools:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6e0;</string>
+	<key>shortcut</key><string>:hammer_and_wrench:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6e1;</string>
+	<key>shortcut</key><string>:shield:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6e2;</string>
+	<key>shortcut</key><string>:oil:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6e2;</string>
+	<key>shortcut</key><string>:oil_drum:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6e3;</string>
+	<key>shortcut</key><string>:motorway:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6e4;</string>
+	<key>shortcut</key><string>:railway_track:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6e4;</string>
+	<key>shortcut</key><string>:railroad_track:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6e5;</string>
+	<key>shortcut</key><string>:motorboat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6e9;</string>
+	<key>shortcut</key><string>:airplane_small:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6e9;</string>
+	<key>shortcut</key><string>:small_airplane:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6eb;</string>
+	<key>shortcut</key><string>:airplane_departure:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6ec;</string>
+	<key>shortcut</key><string>:airplane_arriving:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6f0;</string>
+	<key>shortcut</key><string>:satellite_orbital:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6f3;</string>
+	<key>shortcut</key><string>:cruise_ship:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6f3;</string>
+	<key>shortcut</key><string>:passenger_ship:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6f4;</string>
+	<key>shortcut</key><string>:scooter:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6f5;</string>
+	<key>shortcut</key><string>:motor_scooter:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6f5;</string>
+	<key>shortcut</key><string>:motorbike:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6f6;</string>
+	<key>shortcut</key><string>:canoe:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f6f6;</string>
+	<key>shortcut</key><string>:kayak:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f910;</string>
+	<key>shortcut</key><string>:zipper_mouth:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f910;</string>
+	<key>shortcut</key><string>:zipper_mouth_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f911;</string>
+	<key>shortcut</key><string>:money_mouth:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f911;</string>
+	<key>shortcut</key><string>:money_mouth_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f912;</string>
+	<key>shortcut</key><string>:thermometer_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f912;</string>
+	<key>shortcut</key><string>:face_with_thermometer:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f913;</string>
+	<key>shortcut</key><string>:nerd:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f913;</string>
+	<key>shortcut</key><string>:nerd_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f914;</string>
+	<key>shortcut</key><string>:thinking:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f914;</string>
+	<key>shortcut</key><string>:thinking_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f915;</string>
+	<key>shortcut</key><string>:head_bandage:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f915;</string>
+	<key>shortcut</key><string>:face_with_head_bandage:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f916;</string>
+	<key>shortcut</key><string>:robot:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f916;</string>
+	<key>shortcut</key><string>:robot_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f917;</string>
+	<key>shortcut</key><string>:hugging:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f917;</string>
+	<key>shortcut</key><string>:hugging_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f918;</string>
+	<key>shortcut</key><string>:metal:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f918;</string>
+	<key>shortcut</key><string>:sign_of_the_horns:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f918;&#x1f3fb;</string>
+	<key>shortcut</key><string>:metal_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f918;&#x1f3fb;</string>
+	<key>shortcut</key><string>:sign_of_the_horns_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f918;&#x1f3fc;</string>
+	<key>shortcut</key><string>:metal_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f918;&#x1f3fc;</string>
+	<key>shortcut</key><string>:sign_of_the_horns_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f918;&#x1f3fd;</string>
+	<key>shortcut</key><string>:metal_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f918;&#x1f3fd;</string>
+	<key>shortcut</key><string>:sign_of_the_horns_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f918;&#x1f3fe;</string>
+	<key>shortcut</key><string>:metal_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f918;&#x1f3fe;</string>
+	<key>shortcut</key><string>:sign_of_the_horns_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f918;&#x1f3ff;</string>
+	<key>shortcut</key><string>:metal_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f918;&#x1f3ff;</string>
+	<key>shortcut</key><string>:sign_of_the_horns_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f919;</string>
+	<key>shortcut</key><string>:call_me:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f919;</string>
+	<key>shortcut</key><string>:call_me_hand:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f919;&#x1f3fb;</string>
+	<key>shortcut</key><string>:call_me_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f919;&#x1f3fb;</string>
+	<key>shortcut</key><string>:call_me_hand_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f919;&#x1f3fc;</string>
+	<key>shortcut</key><string>:call_me_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f919;&#x1f3fc;</string>
+	<key>shortcut</key><string>:call_me_hand_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f919;&#x1f3fd;</string>
+	<key>shortcut</key><string>:call_me_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f919;&#x1f3fd;</string>
+	<key>shortcut</key><string>:call_me_hand_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f919;&#x1f3fe;</string>
+	<key>shortcut</key><string>:call_me_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f919;&#x1f3fe;</string>
+	<key>shortcut</key><string>:call_me_hand_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f919;&#x1f3ff;</string>
+	<key>shortcut</key><string>:call_me_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f919;&#x1f3ff;</string>
+	<key>shortcut</key><string>:call_me_hand_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91a;</string>
+	<key>shortcut</key><string>:raised_back_of_hand:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91a;</string>
+	<key>shortcut</key><string>:back_of_hand:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91a;&#x1f3fb;</string>
+	<key>shortcut</key><string>:raised_back_of_hand_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91a;&#x1f3fb;</string>
+	<key>shortcut</key><string>:back_of_hand_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91a;&#x1f3fc;</string>
+	<key>shortcut</key><string>:raised_back_of_hand_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91a;&#x1f3fc;</string>
+	<key>shortcut</key><string>:back_of_hand_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91a;&#x1f3fd;</string>
+	<key>shortcut</key><string>:raised_back_of_hand_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91a;&#x1f3fd;</string>
+	<key>shortcut</key><string>:back_of_hand_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91a;&#x1f3fe;</string>
+	<key>shortcut</key><string>:raised_back_of_hand_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91a;&#x1f3fe;</string>
+	<key>shortcut</key><string>:back_of_hand_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91a;&#x1f3ff;</string>
+	<key>shortcut</key><string>:raised_back_of_hand_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91a;&#x1f3ff;</string>
+	<key>shortcut</key><string>:back_of_hand_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91b;</string>
+	<key>shortcut</key><string>:left_facing_fist:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91b;</string>
+	<key>shortcut</key><string>:left_fist:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91b;&#x1f3fb;</string>
+	<key>shortcut</key><string>:left_facing_fist_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91b;&#x1f3fb;</string>
+	<key>shortcut</key><string>:left_fist_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91b;&#x1f3fc;</string>
+	<key>shortcut</key><string>:left_facing_fist_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91b;&#x1f3fc;</string>
+	<key>shortcut</key><string>:left_fist_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91b;&#x1f3fd;</string>
+	<key>shortcut</key><string>:left_facing_fist_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91b;&#x1f3fd;</string>
+	<key>shortcut</key><string>:left_fist_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91b;&#x1f3fe;</string>
+	<key>shortcut</key><string>:left_facing_fist_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91b;&#x1f3fe;</string>
+	<key>shortcut</key><string>:left_fist_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91b;&#x1f3ff;</string>
+	<key>shortcut</key><string>:left_facing_fist_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91b;&#x1f3ff;</string>
+	<key>shortcut</key><string>:left_fist_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91c;</string>
+	<key>shortcut</key><string>:right_facing_fist:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91c;</string>
+	<key>shortcut</key><string>:right_fist:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91c;&#x1f3fb;</string>
+	<key>shortcut</key><string>:right_facing_fist_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91c;&#x1f3fb;</string>
+	<key>shortcut</key><string>:right_fist_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91c;&#x1f3fc;</string>
+	<key>shortcut</key><string>:right_facing_fist_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91c;&#x1f3fc;</string>
+	<key>shortcut</key><string>:right_fist_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91c;&#x1f3fd;</string>
+	<key>shortcut</key><string>:right_facing_fist_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91c;&#x1f3fd;</string>
+	<key>shortcut</key><string>:right_fist_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91c;&#x1f3fe;</string>
+	<key>shortcut</key><string>:right_facing_fist_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91c;&#x1f3fe;</string>
+	<key>shortcut</key><string>:right_fist_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91c;&#x1f3ff;</string>
+	<key>shortcut</key><string>:right_facing_fist_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91c;&#x1f3ff;</string>
+	<key>shortcut</key><string>:right_fist_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91d;</string>
+	<key>shortcut</key><string>:handshake:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91d;</string>
+	<key>shortcut</key><string>:shaking_hands:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91d;&#x1f3fb;</string>
+	<key>shortcut</key><string>:handshake_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91d;&#x1f3fb;</string>
+	<key>shortcut</key><string>:shaking_hands_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91d;&#x1f3fc;</string>
+	<key>shortcut</key><string>:handshake_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91d;&#x1f3fc;</string>
+	<key>shortcut</key><string>:shaking_hands_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91d;&#x1f3fd;</string>
+	<key>shortcut</key><string>:handshake_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91d;&#x1f3fd;</string>
+	<key>shortcut</key><string>:shaking_hands_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91d;&#x1f3fe;</string>
+	<key>shortcut</key><string>:handshake_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91d;&#x1f3fe;</string>
+	<key>shortcut</key><string>:shaking_hands_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91d;&#x1f3ff;</string>
+	<key>shortcut</key><string>:handshake_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91d;&#x1f3ff;</string>
+	<key>shortcut</key><string>:shaking_hands_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91e;</string>
+	<key>shortcut</key><string>:fingers_crossed:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91e;</string>
+	<key>shortcut</key><string>:hand_with_index_and_middle_finger_crossed:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91e;&#x1f3fb;</string>
+	<key>shortcut</key><string>:fingers_crossed_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91e;&#x1f3fb;</string>
+	<key>shortcut</key><string>:hand_with_index_and_middle_fingers_crossed_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91e;&#x1f3fc;</string>
+	<key>shortcut</key><string>:fingers_crossed_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91e;&#x1f3fc;</string>
+	<key>shortcut</key><string>:hand_with_index_and_middle_fingers_crossed_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91e;&#x1f3fd;</string>
+	<key>shortcut</key><string>:fingers_crossed_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91e;&#x1f3fd;</string>
+	<key>shortcut</key><string>:hand_with_index_and_middle_fingers_crossed_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91e;&#x1f3fe;</string>
+	<key>shortcut</key><string>:fingers_crossed_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91e;&#x1f3fe;</string>
+	<key>shortcut</key><string>:hand_with_index_and_middle_fingers_crossed_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91e;&#x1f3ff;</string>
+	<key>shortcut</key><string>:fingers_crossed_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f91e;&#x1f3ff;</string>
+	<key>shortcut</key><string>:hand_with_index_and_middle_fingers_crossed_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f920;</string>
+	<key>shortcut</key><string>:cowboy:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f920;</string>
+	<key>shortcut</key><string>:face_with_cowboy_hat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f921;</string>
+	<key>shortcut</key><string>:clown:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f921;</string>
+	<key>shortcut</key><string>:clown_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f922;</string>
+	<key>shortcut</key><string>:nauseated_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f922;</string>
+	<key>shortcut</key><string>:sick:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f923;</string>
+	<key>shortcut</key><string>:rofl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f923;</string>
+	<key>shortcut</key><string>:rolling_on_the_floor_laughing:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f924;</string>
+	<key>shortcut</key><string>:drooling_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f924;</string>
+	<key>shortcut</key><string>:drool:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f925;</string>
+	<key>shortcut</key><string>:lying_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f925;</string>
+	<key>shortcut</key><string>:liar:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f926;</string>
+	<key>shortcut</key><string>:face_palm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f926;</string>
+	<key>shortcut</key><string>:facepalm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f926;&#x1f3fb;</string>
+	<key>shortcut</key><string>:face_palm_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f926;&#x1f3fb;</string>
+	<key>shortcut</key><string>:facepalm_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f926;&#x1f3fc;</string>
+	<key>shortcut</key><string>:face_palm_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f926;&#x1f3fc;</string>
+	<key>shortcut</key><string>:facepalm_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f926;&#x1f3fd;</string>
+	<key>shortcut</key><string>:face_palm_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f926;&#x1f3fd;</string>
+	<key>shortcut</key><string>:facepalm_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f926;&#x1f3fe;</string>
+	<key>shortcut</key><string>:face_palm_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f926;&#x1f3fe;</string>
+	<key>shortcut</key><string>:facepalm_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f926;&#x1f3ff;</string>
+	<key>shortcut</key><string>:face_palm_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f926;&#x1f3ff;</string>
+	<key>shortcut</key><string>:facepalm_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f927;</string>
+	<key>shortcut</key><string>:sneezing_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f927;</string>
+	<key>shortcut</key><string>:sneeze:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f930;</string>
+	<key>shortcut</key><string>:pregnant_woman:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f930;</string>
+	<key>shortcut</key><string>:expecting_woman:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f930;&#x1f3fb;</string>
+	<key>shortcut</key><string>:pregnant_woman_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f930;&#x1f3fb;</string>
+	<key>shortcut</key><string>:expecting_woman_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f930;&#x1f3fc;</string>
+	<key>shortcut</key><string>:pregnant_woman_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f930;&#x1f3fc;</string>
+	<key>shortcut</key><string>:expecting_woman_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f930;&#x1f3fd;</string>
+	<key>shortcut</key><string>:pregnant_woman_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f930;&#x1f3fd;</string>
+	<key>shortcut</key><string>:expecting_woman_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f930;&#x1f3fe;</string>
+	<key>shortcut</key><string>:pregnant_woman_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f930;&#x1f3fe;</string>
+	<key>shortcut</key><string>:expecting_woman_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f930;&#x1f3ff;</string>
+	<key>shortcut</key><string>:pregnant_woman_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f930;&#x1f3ff;</string>
+	<key>shortcut</key><string>:expecting_woman_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f933;</string>
+	<key>shortcut</key><string>:selfie:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f933;&#x1f3fb;</string>
+	<key>shortcut</key><string>:selfie_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f933;&#x1f3fc;</string>
+	<key>shortcut</key><string>:selfie_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f933;&#x1f3fd;</string>
+	<key>shortcut</key><string>:selfie_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f933;&#x1f3fe;</string>
+	<key>shortcut</key><string>:selfie_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f933;&#x1f3ff;</string>
+	<key>shortcut</key><string>:selfie_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f934;</string>
+	<key>shortcut</key><string>:prince:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f934;&#x1f3fb;</string>
+	<key>shortcut</key><string>:prince_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f934;&#x1f3fc;</string>
+	<key>shortcut</key><string>:prince_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f934;&#x1f3fd;</string>
+	<key>shortcut</key><string>:prince_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f934;&#x1f3fe;</string>
+	<key>shortcut</key><string>:prince_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f934;&#x1f3ff;</string>
+	<key>shortcut</key><string>:prince_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f935;</string>
+	<key>shortcut</key><string>:man_in_tuxedo:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f935;&#x1f3fb;</string>
+	<key>shortcut</key><string>:man_in_tuxedo_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f935;&#x1f3fb;</string>
+	<key>shortcut</key><string>:tuxedo_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f935;&#x1f3fc;</string>
+	<key>shortcut</key><string>:man_in_tuxedo_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f935;&#x1f3fc;</string>
+	<key>shortcut</key><string>:tuxedo_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f935;&#x1f3fd;</string>
+	<key>shortcut</key><string>:man_in_tuxedo_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f935;&#x1f3fd;</string>
+	<key>shortcut</key><string>:tuxedo_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f935;&#x1f3fe;</string>
+	<key>shortcut</key><string>:man_in_tuxedo_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f935;&#x1f3fe;</string>
+	<key>shortcut</key><string>:tuxedo_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f935;&#x1f3ff;</string>
+	<key>shortcut</key><string>:man_in_tuxedo_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f935;&#x1f3ff;</string>
+	<key>shortcut</key><string>:tuxedo_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f936;</string>
+	<key>shortcut</key><string>:mrs_claus:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f936;</string>
+	<key>shortcut</key><string>:mother_christmas:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f936;&#x1f3fb;</string>
+	<key>shortcut</key><string>:mrs_claus_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f936;&#x1f3fb;</string>
+	<key>shortcut</key><string>:mother_christmas_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f936;&#x1f3fc;</string>
+	<key>shortcut</key><string>:mrs_claus_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f936;&#x1f3fc;</string>
+	<key>shortcut</key><string>:mother_christmas_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f936;&#x1f3fd;</string>
+	<key>shortcut</key><string>:mrs_claus_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f936;&#x1f3fd;</string>
+	<key>shortcut</key><string>:mother_christmas_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f936;&#x1f3fe;</string>
+	<key>shortcut</key><string>:mrs_claus_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f936;&#x1f3fe;</string>
+	<key>shortcut</key><string>:mother_christmas_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f936;&#x1f3ff;</string>
+	<key>shortcut</key><string>:mrs_claus_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f936;&#x1f3ff;</string>
+	<key>shortcut</key><string>:mother_christmas_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f937;</string>
+	<key>shortcut</key><string>:shrug:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f937;&#x1f3fb;</string>
+	<key>shortcut</key><string>:shrug_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f937;&#x1f3fc;</string>
+	<key>shortcut</key><string>:shrug_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f937;&#x1f3fd;</string>
+	<key>shortcut</key><string>:shrug_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f937;&#x1f3fe;</string>
+	<key>shortcut</key><string>:shrug_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f937;&#x1f3ff;</string>
+	<key>shortcut</key><string>:shrug_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f938;</string>
+	<key>shortcut</key><string>:cartwheel:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f938;</string>
+	<key>shortcut</key><string>:person_doing_cartwheel:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f938;&#x1f3fb;</string>
+	<key>shortcut</key><string>:cartwheel_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f938;&#x1f3fb;</string>
+	<key>shortcut</key><string>:person_doing_cartwheel_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f938;&#x1f3fc;</string>
+	<key>shortcut</key><string>:cartwheel_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f938;&#x1f3fc;</string>
+	<key>shortcut</key><string>:person_doing_cartwheel_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f938;&#x1f3fd;</string>
+	<key>shortcut</key><string>:cartwheel_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f938;&#x1f3fd;</string>
+	<key>shortcut</key><string>:person_doing_cartwheel_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f938;&#x1f3fe;</string>
+	<key>shortcut</key><string>:cartwheel_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f938;&#x1f3fe;</string>
+	<key>shortcut</key><string>:person_doing_cartwheel_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f938;&#x1f3ff;</string>
+	<key>shortcut</key><string>:cartwheel_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f938;&#x1f3ff;</string>
+	<key>shortcut</key><string>:person_doing_cartwheel_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f939;</string>
+	<key>shortcut</key><string>:juggling:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f939;</string>
+	<key>shortcut</key><string>:juggler:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f939;&#x1f3fb;</string>
+	<key>shortcut</key><string>:juggling_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f939;&#x1f3fb;</string>
+	<key>shortcut</key><string>:juggler_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f939;&#x1f3fc;</string>
+	<key>shortcut</key><string>:juggling_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f939;&#x1f3fc;</string>
+	<key>shortcut</key><string>:juggler_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f939;&#x1f3fd;</string>
+	<key>shortcut</key><string>:juggling_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f939;&#x1f3fd;</string>
+	<key>shortcut</key><string>:juggler_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f939;&#x1f3fe;</string>
+	<key>shortcut</key><string>:juggling_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f939;&#x1f3fe;</string>
+	<key>shortcut</key><string>:juggler_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f939;&#x1f3ff;</string>
+	<key>shortcut</key><string>:juggling_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f939;&#x1f3ff;</string>
+	<key>shortcut</key><string>:juggler_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93a;</string>
+	<key>shortcut</key><string>:fencer:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93a;</string>
+	<key>shortcut</key><string>:fencing:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93c;</string>
+	<key>shortcut</key><string>:wrestlers:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93c;</string>
+	<key>shortcut</key><string>:wrestling:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93c;&#x1f3fb;</string>
+	<key>shortcut</key><string>:wrestlers_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93c;&#x1f3fb;</string>
+	<key>shortcut</key><string>:wrestling_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93c;&#x1f3fc;</string>
+	<key>shortcut</key><string>:wrestlers_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93c;&#x1f3fc;</string>
+	<key>shortcut</key><string>:wrestling_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93c;&#x1f3fd;</string>
+	<key>shortcut</key><string>:wrestlers_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93c;&#x1f3fd;</string>
+	<key>shortcut</key><string>:wrestling_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93c;&#x1f3fe;</string>
+	<key>shortcut</key><string>:wrestlers_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93c;&#x1f3fe;</string>
+	<key>shortcut</key><string>:wrestling_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93c;&#x1f3ff;</string>
+	<key>shortcut</key><string>:wrestlers_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93c;&#x1f3ff;</string>
+	<key>shortcut</key><string>:wrestling_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93d;</string>
+	<key>shortcut</key><string>:water_polo:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93d;&#x1f3fb;</string>
+	<key>shortcut</key><string>:water_polo_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93d;&#x1f3fc;</string>
+	<key>shortcut</key><string>:water_polo_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93d;&#x1f3fd;</string>
+	<key>shortcut</key><string>:water_polo_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93d;&#x1f3fe;</string>
+	<key>shortcut</key><string>:water_polo_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93d;&#x1f3ff;</string>
+	<key>shortcut</key><string>:water_polo_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93e;</string>
+	<key>shortcut</key><string>:handball:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93e;&#x1f3fb;</string>
+	<key>shortcut</key><string>:handball_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93e;&#x1f3fc;</string>
+	<key>shortcut</key><string>:handball_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93e;&#x1f3fd;</string>
+	<key>shortcut</key><string>:handball_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93e;&#x1f3fe;</string>
+	<key>shortcut</key><string>:handball_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f93e;&#x1f3ff;</string>
+	<key>shortcut</key><string>:handball_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f940;</string>
+	<key>shortcut</key><string>:wilted_rose:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f940;</string>
+	<key>shortcut</key><string>:wilted_flower:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f941;</string>
+	<key>shortcut</key><string>:drum:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f941;</string>
+	<key>shortcut</key><string>:drum_with_drumsticks:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f942;</string>
+	<key>shortcut</key><string>:champagne_glass:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f942;</string>
+	<key>shortcut</key><string>:clinking_glass:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f943;</string>
+	<key>shortcut</key><string>:tumbler_glass:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f943;</string>
+	<key>shortcut</key><string>:whisky:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f944;</string>
+	<key>shortcut</key><string>:spoon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f945;</string>
+	<key>shortcut</key><string>:goal:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f945;</string>
+	<key>shortcut</key><string>:goal_net:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f947;</string>
+	<key>shortcut</key><string>:first_place:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f947;</string>
+	<key>shortcut</key><string>:first_place_medal:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f948;</string>
+	<key>shortcut</key><string>:second_place:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f948;</string>
+	<key>shortcut</key><string>:second_place_medal:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f949;</string>
+	<key>shortcut</key><string>:third_place:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f949;</string>
+	<key>shortcut</key><string>:third_place_medal:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f94a;</string>
+	<key>shortcut</key><string>:boxing_glove:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f94a;</string>
+	<key>shortcut</key><string>:boxing_gloves:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f94b;</string>
+	<key>shortcut</key><string>:martial_arts_uniform:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f94b;</string>
+	<key>shortcut</key><string>:karate_uniform:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f950;</string>
+	<key>shortcut</key><string>:croissant:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f951;</string>
+	<key>shortcut</key><string>:avocado:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f952;</string>
+	<key>shortcut</key><string>:cucumber:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f953;</string>
+	<key>shortcut</key><string>:bacon:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f954;</string>
+	<key>shortcut</key><string>:potato:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f955;</string>
+	<key>shortcut</key><string>:carrot:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f956;</string>
+	<key>shortcut</key><string>:french_bread:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f956;</string>
+	<key>shortcut</key><string>:baguette_bread:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f957;</string>
+	<key>shortcut</key><string>:salad:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f957;</string>
+	<key>shortcut</key><string>:green_salad:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f958;</string>
+	<key>shortcut</key><string>:shallow_pan_of_food:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f958;</string>
+	<key>shortcut</key><string>:paella:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f959;</string>
+	<key>shortcut</key><string>:stuffed_flatbread:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f959;</string>
+	<key>shortcut</key><string>:stuffed_pita:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f95a;</string>
+	<key>shortcut</key><string>:egg:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f95b;</string>
+	<key>shortcut</key><string>:milk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f95b;</string>
+	<key>shortcut</key><string>:glass_of_milk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f95c;</string>
+	<key>shortcut</key><string>:peanuts:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f95c;</string>
+	<key>shortcut</key><string>:shelled_peanut:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f95d;</string>
+	<key>shortcut</key><string>:kiwi:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f95d;</string>
+	<key>shortcut</key><string>:kiwifruit:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f95e;</string>
+	<key>shortcut</key><string>:pancakes:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f980;</string>
+	<key>shortcut</key><string>:crab:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f981;</string>
+	<key>shortcut</key><string>:lion_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f981;</string>
+	<key>shortcut</key><string>:lion:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f982;</string>
+	<key>shortcut</key><string>:scorpion:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f983;</string>
+	<key>shortcut</key><string>:turkey:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f984;</string>
+	<key>shortcut</key><string>:unicorn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f984;</string>
+	<key>shortcut</key><string>:unicorn_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f985;</string>
+	<key>shortcut</key><string>:eagle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f986;</string>
+	<key>shortcut</key><string>:duck:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f987;</string>
+	<key>shortcut</key><string>:bat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f988;</string>
+	<key>shortcut</key><string>:shark:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f989;</string>
+	<key>shortcut</key><string>:owl:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f98a;</string>
+	<key>shortcut</key><string>:fox:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f98a;</string>
+	<key>shortcut</key><string>:fox_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f98b;</string>
+	<key>shortcut</key><string>:butterfly:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f98c;</string>
+	<key>shortcut</key><string>:deer:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f98d;</string>
+	<key>shortcut</key><string>:gorilla:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f98e;</string>
+	<key>shortcut</key><string>:lizard:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f98f;</string>
+	<key>shortcut</key><string>:rhino:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f98f;</string>
+	<key>shortcut</key><string>:rhinoceros:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f990;</string>
+	<key>shortcut</key><string>:shrimp:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f991;</string>
+	<key>shortcut</key><string>:squid:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f9c0;</string>
+	<key>shortcut</key><string>:cheese:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x1f9c0;</string>
+	<key>shortcut</key><string>:cheese_wedge:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x203c;</string>
+	<key>shortcut</key><string>:bangbang:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2049;</string>
+	<key>shortcut</key><string>:interrobang:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2122;</string>
+	<key>shortcut</key><string>:tm:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2139;</string>
+	<key>shortcut</key><string>:information_source:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2194;</string>
+	<key>shortcut</key><string>:left_right_arrow:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2195;</string>
+	<key>shortcut</key><string>:arrow_up_down:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2196;</string>
+	<key>shortcut</key><string>:arrow_upper_left:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2197;</string>
+	<key>shortcut</key><string>:arrow_upper_right:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2198;</string>
+	<key>shortcut</key><string>:arrow_lower_right:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2199;</string>
+	<key>shortcut</key><string>:arrow_lower_left:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x21a9;</string>
+	<key>shortcut</key><string>:leftwards_arrow_with_hook:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x21aa;</string>
+	<key>shortcut</key><string>:arrow_right_hook:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x231a;</string>
+	<key>shortcut</key><string>:watch:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x231b;</string>
+	<key>shortcut</key><string>:hourglass:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2328;</string>
+	<key>shortcut</key><string>:keyboard:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23cf;</string>
+	<key>shortcut</key><string>:eject:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23cf;</string>
+	<key>shortcut</key><string>:eject_symbol:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23e9;</string>
+	<key>shortcut</key><string>:fast_forward:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23ea;</string>
+	<key>shortcut</key><string>:rewind:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23eb;</string>
+	<key>shortcut</key><string>:arrow_double_up:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23ec;</string>
+	<key>shortcut</key><string>:arrow_double_down:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23ed;</string>
+	<key>shortcut</key><string>:track_next:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23ed;</string>
+	<key>shortcut</key><string>:next_track:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23ee;</string>
+	<key>shortcut</key><string>:track_previous:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23ee;</string>
+	<key>shortcut</key><string>:previous_track:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23ef;</string>
+	<key>shortcut</key><string>:play_pause:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23f0;</string>
+	<key>shortcut</key><string>:alarm_clock:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23f1;</string>
+	<key>shortcut</key><string>:stopwatch:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23f2;</string>
+	<key>shortcut</key><string>:timer:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23f2;</string>
+	<key>shortcut</key><string>:timer_clock:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23f3;</string>
+	<key>shortcut</key><string>:hourglass_flowing_sand:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23f8;</string>
+	<key>shortcut</key><string>:pause_button:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23f8;</string>
+	<key>shortcut</key><string>:double_vertical_bar:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23f9;</string>
+	<key>shortcut</key><string>:stop_button:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x23fa;</string>
+	<key>shortcut</key><string>:record_button:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x24c2;</string>
+	<key>shortcut</key><string>:m:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x25aa;</string>
+	<key>shortcut</key><string>:black_small_square:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x25ab;</string>
+	<key>shortcut</key><string>:white_small_square:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x25b6;</string>
+	<key>shortcut</key><string>:arrow_forward:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x25c0;</string>
+	<key>shortcut</key><string>:arrow_backward:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x25fb;</string>
+	<key>shortcut</key><string>:white_medium_square:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x25fc;</string>
+	<key>shortcut</key><string>:black_medium_square:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x25fd;</string>
+	<key>shortcut</key><string>:white_medium_small_square:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x25fe;</string>
+	<key>shortcut</key><string>:black_medium_small_square:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2600;</string>
+	<key>shortcut</key><string>:sunny:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2601;</string>
+	<key>shortcut</key><string>:cloud:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2602;</string>
+	<key>shortcut</key><string>:umbrella2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2603;</string>
+	<key>shortcut</key><string>:snowman2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2604;</string>
+	<key>shortcut</key><string>:comet:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x260e;</string>
+	<key>shortcut</key><string>:telephone:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2611;</string>
+	<key>shortcut</key><string>:ballot_box_with_check:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2614;</string>
+	<key>shortcut</key><string>:umbrella:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2615;</string>
+	<key>shortcut</key><string>:coffee:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2618;</string>
+	<key>shortcut</key><string>:shamrock:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x261d;</string>
+	<key>shortcut</key><string>:point_up:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x261d;&#x1f3fb;</string>
+	<key>shortcut</key><string>:point_up_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x261d;&#x1f3fc;</string>
+	<key>shortcut</key><string>:point_up_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x261d;&#x1f3fd;</string>
+	<key>shortcut</key><string>:point_up_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x261d;&#x1f3fe;</string>
+	<key>shortcut</key><string>:point_up_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x261d;&#x1f3ff;</string>
+	<key>shortcut</key><string>:point_up_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2620;</string>
+	<key>shortcut</key><string>:skull_crossbones:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2620;</string>
+	<key>shortcut</key><string>:skull_and_crossbones:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2622;</string>
+	<key>shortcut</key><string>:radioactive:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2622;</string>
+	<key>shortcut</key><string>:radioactive_sign:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2623;</string>
+	<key>shortcut</key><string>:biohazard:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2623;</string>
+	<key>shortcut</key><string>:biohazard_sign:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2626;</string>
+	<key>shortcut</key><string>:orthodox_cross:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x262a;</string>
+	<key>shortcut</key><string>:star_and_crescent:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x262e;</string>
+	<key>shortcut</key><string>:peace:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x262e;</string>
+	<key>shortcut</key><string>:peace_symbol:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x262f;</string>
+	<key>shortcut</key><string>:yin_yang:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2638;</string>
+	<key>shortcut</key><string>:wheel_of_dharma:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2639;</string>
+	<key>shortcut</key><string>:frowning2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2639;</string>
+	<key>shortcut</key><string>:white_frowning_face:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x263a;</string>
+	<key>shortcut</key><string>:relaxed:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2648;</string>
+	<key>shortcut</key><string>:aries:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2649;</string>
+	<key>shortcut</key><string>:taurus:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x264a;</string>
+	<key>shortcut</key><string>:gemini:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x264b;</string>
+	<key>shortcut</key><string>:cancer:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x264c;</string>
+	<key>shortcut</key><string>:leo:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x264d;</string>
+	<key>shortcut</key><string>:virgo:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x264e;</string>
+	<key>shortcut</key><string>:libra:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x264f;</string>
+	<key>shortcut</key><string>:scorpius:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2650;</string>
+	<key>shortcut</key><string>:sagittarius:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2651;</string>
+	<key>shortcut</key><string>:capricorn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2652;</string>
+	<key>shortcut</key><string>:aquarius:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2653;</string>
+	<key>shortcut</key><string>:pisces:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2660;</string>
+	<key>shortcut</key><string>:spades:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2663;</string>
+	<key>shortcut</key><string>:clubs:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2665;</string>
+	<key>shortcut</key><string>:hearts:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2666;</string>
+	<key>shortcut</key><string>:diamonds:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2668;</string>
+	<key>shortcut</key><string>:hotsprings:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x267b;</string>
+	<key>shortcut</key><string>:recycle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x267f;</string>
+	<key>shortcut</key><string>:wheelchair:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2692;</string>
+	<key>shortcut</key><string>:hammer_pick:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2692;</string>
+	<key>shortcut</key><string>:hammer_and_pick:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2693;</string>
+	<key>shortcut</key><string>:anchor:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2694;</string>
+	<key>shortcut</key><string>:crossed_swords:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2696;</string>
+	<key>shortcut</key><string>:scales:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2697;</string>
+	<key>shortcut</key><string>:alembic:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2699;</string>
+	<key>shortcut</key><string>:gear:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x269b;</string>
+	<key>shortcut</key><string>:atom:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x269b;</string>
+	<key>shortcut</key><string>:atom_symbol:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x269c;</string>
+	<key>shortcut</key><string>:fleur-de-lis:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26a0;</string>
+	<key>shortcut</key><string>:warning:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26a1;</string>
+	<key>shortcut</key><string>:zap:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26aa;</string>
+	<key>shortcut</key><string>:white_circle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26ab;</string>
+	<key>shortcut</key><string>:black_circle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26b0;</string>
+	<key>shortcut</key><string>:coffin:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26b1;</string>
+	<key>shortcut</key><string>:urn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26b1;</string>
+	<key>shortcut</key><string>:funeral_urn:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26bd;</string>
+	<key>shortcut</key><string>:soccer:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26be;</string>
+	<key>shortcut</key><string>:baseball:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26c4;</string>
+	<key>shortcut</key><string>:snowman:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26c5;</string>
+	<key>shortcut</key><string>:partly_sunny:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26c8;</string>
+	<key>shortcut</key><string>:thunder_cloud_rain:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26c8;</string>
+	<key>shortcut</key><string>:thunder_cloud_and_rain:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26ce;</string>
+	<key>shortcut</key><string>:ophiuchus:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26cf;</string>
+	<key>shortcut</key><string>:pick:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26d1;</string>
+	<key>shortcut</key><string>:helmet_with_cross:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26d1;</string>
+	<key>shortcut</key><string>:helmet_with_white_cross:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26d3;</string>
+	<key>shortcut</key><string>:chains:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26d4;</string>
+	<key>shortcut</key><string>:no_entry:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26e9;</string>
+	<key>shortcut</key><string>:shinto_shrine:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26ea;</string>
+	<key>shortcut</key><string>:church:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f0;</string>
+	<key>shortcut</key><string>:mountain:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f1;</string>
+	<key>shortcut</key><string>:beach_umbrella:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f1;</string>
+	<key>shortcut</key><string>:umbrella_on_ground:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f2;</string>
+	<key>shortcut</key><string>:fountain:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f3;</string>
+	<key>shortcut</key><string>:golf:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f4;</string>
+	<key>shortcut</key><string>:ferry:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f5;</string>
+	<key>shortcut</key><string>:sailboat:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f7;</string>
+	<key>shortcut</key><string>:skier:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f8;</string>
+	<key>shortcut</key><string>:ice_skate:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f9;</string>
+	<key>shortcut</key><string>:basketball_player:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f9;</string>
+	<key>shortcut</key><string>:person_with_ball:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f9;&#x1f3fb;</string>
+	<key>shortcut</key><string>:basketball_player_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f9;&#x1f3fb;</string>
+	<key>shortcut</key><string>:person_with_ball_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f9;&#x1f3fc;</string>
+	<key>shortcut</key><string>:basketball_player_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f9;&#x1f3fc;</string>
+	<key>shortcut</key><string>:person_with_ball_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f9;&#x1f3fd;</string>
+	<key>shortcut</key><string>:basketball_player_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f9;&#x1f3fd;</string>
+	<key>shortcut</key><string>:person_with_ball_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f9;&#x1f3fe;</string>
+	<key>shortcut</key><string>:basketball_player_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f9;&#x1f3fe;</string>
+	<key>shortcut</key><string>:person_with_ball_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f9;&#x1f3ff;</string>
+	<key>shortcut</key><string>:basketball_player_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26f9;&#x1f3ff;</string>
+	<key>shortcut</key><string>:person_with_ball_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26fa;</string>
+	<key>shortcut</key><string>:tent:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x26fd;</string>
+	<key>shortcut</key><string>:fuelpump:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2702;</string>
+	<key>shortcut</key><string>:scissors:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2705;</string>
+	<key>shortcut</key><string>:white_check_mark:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2708;</string>
+	<key>shortcut</key><string>:airplane:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2709;</string>
+	<key>shortcut</key><string>:envelope:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270a;</string>
+	<key>shortcut</key><string>:fist:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270a;&#x1f3fb;</string>
+	<key>shortcut</key><string>:fist_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270a;&#x1f3fc;</string>
+	<key>shortcut</key><string>:fist_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270a;&#x1f3fd;</string>
+	<key>shortcut</key><string>:fist_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270a;&#x1f3fe;</string>
+	<key>shortcut</key><string>:fist_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270a;&#x1f3ff;</string>
+	<key>shortcut</key><string>:fist_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270b;</string>
+	<key>shortcut</key><string>:raised_hand:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270b;&#x1f3fb;</string>
+	<key>shortcut</key><string>:raised_hand_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270b;&#x1f3fc;</string>
+	<key>shortcut</key><string>:raised_hand_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270b;&#x1f3fd;</string>
+	<key>shortcut</key><string>:raised_hand_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270b;&#x1f3fe;</string>
+	<key>shortcut</key><string>:raised_hand_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270b;&#x1f3ff;</string>
+	<key>shortcut</key><string>:raised_hand_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270c;</string>
+	<key>shortcut</key><string>:v:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270c;&#x1f3fb;</string>
+	<key>shortcut</key><string>:v_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270c;&#x1f3fc;</string>
+	<key>shortcut</key><string>:v_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270c;&#x1f3fd;</string>
+	<key>shortcut</key><string>:v_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270c;&#x1f3fe;</string>
+	<key>shortcut</key><string>:v_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270c;&#x1f3ff;</string>
+	<key>shortcut</key><string>:v_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270d;</string>
+	<key>shortcut</key><string>:writing_hand:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270d;&#x1f3fb;</string>
+	<key>shortcut</key><string>:writing_hand_tone1:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270d;&#x1f3fc;</string>
+	<key>shortcut</key><string>:writing_hand_tone2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270d;&#x1f3fd;</string>
+	<key>shortcut</key><string>:writing_hand_tone3:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270d;&#x1f3fe;</string>
+	<key>shortcut</key><string>:writing_hand_tone4:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270d;&#x1f3ff;</string>
+	<key>shortcut</key><string>:writing_hand_tone5:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x270f;</string>
+	<key>shortcut</key><string>:pencil2:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2712;</string>
+	<key>shortcut</key><string>:black_nib:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2714;</string>
+	<key>shortcut</key><string>:heavy_check_mark:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2716;</string>
+	<key>shortcut</key><string>:heavy_multiplication_x:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x271d;</string>
+	<key>shortcut</key><string>:cross:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x271d;</string>
+	<key>shortcut</key><string>:latin_cross:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2721;</string>
+	<key>shortcut</key><string>:star_of_david:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2728;</string>
+	<key>shortcut</key><string>:sparkles:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2733;</string>
+	<key>shortcut</key><string>:eight_spoked_asterisk:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2734;</string>
+	<key>shortcut</key><string>:eight_pointed_black_star:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2744;</string>
+	<key>shortcut</key><string>:snowflake:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2747;</string>
+	<key>shortcut</key><string>:sparkle:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x274c;</string>
+	<key>shortcut</key><string>:x:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x274e;</string>
+	<key>shortcut</key><string>:negative_squared_cross_mark:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2753;</string>
+	<key>shortcut</key><string>:question:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2754;</string>
+	<key>shortcut</key><string>:grey_question:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2755;</string>
+	<key>shortcut</key><string>:grey_exclamation:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2757;</string>
+	<key>shortcut</key><string>:exclamation:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2763;</string>
+	<key>shortcut</key><string>:heart_exclamation:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2763;</string>
+	<key>shortcut</key><string>:heavy_heart_exclamation_mark_ornament:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2764;</string>
+	<key>shortcut</key><string>:heart:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2795;</string>
+	<key>shortcut</key><string>:heavy_plus_sign:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2796;</string>
+	<key>shortcut</key><string>:heavy_minus_sign:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2797;</string>
+	<key>shortcut</key><string>:heavy_division_sign:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x27a1;</string>
+	<key>shortcut</key><string>:arrow_right:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x27b0;</string>
+	<key>shortcut</key><string>:curly_loop:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x27bf;</string>
+	<key>shortcut</key><string>:loop:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2934;</string>
+	<key>shortcut</key><string>:arrow_heading_up:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2935;</string>
+	<key>shortcut</key><string>:arrow_heading_down:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2b05;</string>
+	<key>shortcut</key><string>:arrow_left:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2b06;</string>
+	<key>shortcut</key><string>:arrow_up:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2b07;</string>
+	<key>shortcut</key><string>:arrow_down:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2b1b;</string>
+	<key>shortcut</key><string>:black_large_square:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2b1c;</string>
+	<key>shortcut</key><string>:white_large_square:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2b50;</string>
+	<key>shortcut</key><string>:star:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x2b55;</string>
+	<key>shortcut</key><string>:o:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x3030;</string>
+	<key>shortcut</key><string>:wavy_dash:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x303d;</string>
+	<key>shortcut</key><string>:part_alternation_mark:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x3297;</string>
+	<key>shortcut</key><string>:congratulations:</string>
+</dict>
+<dict>
+	<key>phrase</key><string>&#x3299;</string>
+	<key>shortcut</key><string>:secret:</string>
+</dict>
+</array>
+</plist>


### PR DESCRIPTION
- https://support.apple.com/en-us/HT204006
- https://github.com/warpling/Macmoji 

I am not sure which convention Macmoji is using, but it has been suggested to them to switch to [Emojilib](https://github.com/muan/emojilib) https://github.com/warpling/Macmoji/issues/33, which is based upon [/github/gemoji](https://github.com/github/gemoji) (which via [/WebpageFX/emoji-cheat-sheet.com](https://github.com/WebpageFX/emoji-cheat-sheet.com) also powers [Emoji Cheat Sheet](https://www.webpagefx.com/tools/emoji-cheat-sheet/)).